### PR TITLE
Feed download fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ cache:
   directories:
   - "$HOME/.m2/repository"
 before_install:
-- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g'
-  ~/.m2/settings.xml
+#- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 script:
 - mvn package -DskipTests
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ cache:
 before_install:
 #- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 script:
-- mvn package -DskipTests
+# package jar
+- mvn package
+# notify slack channel of build status
 notifications:
   slack: conveyal:WQxmWiu8PdmujwLw4ziW72Gc
 before_deploy:
+# get branch name of current branch for use in jar name: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+# copy packaged jars over to deploy dir
 - mkdir deploy
 - cp target/dt-*.jar deploy/
 - cp "target/dt-$(git describe --always).jar" "deploy/dt-latest-${BRANCH}.jar"
@@ -23,6 +27,7 @@ deploy:
   access_key_id: AKIAJISY76KTZBNHS4SA
   secret_access_key:
     secure: a2PNYiv7kzgKxfSx6IhZxSCFBZTCjrbIAK/vmCB1KcpnlV4vTt/IL13i3u6XC8wAbUxhd6iJMtVRm4diIwmy0K7nnpp0h3cQDxYqWCmf1dHZWBJXkpurDpbfxW5G6IlL14i+EsTSCpmwalov+atOBDVyJWVGqfEYaj9c6Q1E0fiYNP3QwZQcsVuD1CRw91xzckfERwqYcz70p/hmTEPOgUwDHuyHsjFafJx+krY3mnBdRdDRLcnPavjcEtprjGkdiVbNETe3CHVNQrAVfqm187OoDA2tHTPjTFmlAdUedp4rYqLmF/WWbHZLzUkQb95FJkklx30vlwC0bIutP1TwIlr3ma5aCRFc58x3SzG07AeM+vbt/nh5A52cpdRjBnhctC2kL++QvwkJhwRy2xptl/WEd5AUagoN4ngnGzyDS4kk/taQFL0IAav5C2WH668kGyH17KNeWG/bCDd55oCvwNlppAYXH+WdbtylqiVb9Fllvs1wcIYWqqyX5zdYiyFEI8LyEQsNF/D5ekuAtLXcF25uwjNtHMjdAxQxHbAbBOeaaLwJd29os9GrKFI/2C0TVXZo2zaFLZyFaIsDHqAC+MXDBDtktimC9Uuozz7bXENCrOUBfsDEQXb46tkXLGaQNXeOhe3KwVKxlGDCsLb7iHIcdDyBm19hqUWhU3uA+dU=
+  # upload jars in deploy dir to bucket
   bucket: datatools-builds
   local-dir: deploy
   acl: public_read

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
   - "$HOME/.m2/repository"
 before_install:
 #- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
+# set region in AWS config for S3 setup
+- printf '%s\n' '[default]' 'aws_access_key_id=foo' 'aws_secret_access_key=bar' 'region=us-east-1' > ~/.aws/config
 script:
 # package jar
 - mvn package

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 before_install:
 #- sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 # set region in AWS config for S3 setup
-- printf '%s\n' '[default]' 'aws_access_key_id=foo' 'aws_secret_access_key=bar' 'region=us-east-1' > ~/.aws/config
+- mkdir ~/.aws && printf '%s\n' '[default]' 'aws_access_key_id=foo' 'aws_secret_access_key=bar' 'region=us-east-1' > ~/.aws/config
 script:
 # package jar
 - mvn package

--- a/src/main/java/com/conveyal/datatools/common/utils/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/S3Utils.java
@@ -101,7 +101,6 @@ public class S3Utils {
         Set<Statement> statements = new HashSet<>();
         statements.add(statement);
         policy.setStatements(statements);
-        System.out.println(policy.toJson());
         AssumeRoleRequest assumeRequest = new AssumeRoleRequest()
                 .withRoleArn(ROLE_ARN)
                 .withPolicy(policy.toJson()) // some policy that limits access to certain objects (intersects with ROLE_ARN policies

--- a/src/main/java/com/conveyal/datatools/common/utils/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/S3Utils.java
@@ -86,6 +86,17 @@ public class S3Utils {
         }
     }
 
+    /**
+     * Create temporary S3 credentials in order to grant access to some set of objects (s3://bucket/key)
+     * using a predefined role.  More info here: http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/prog-services-sts.html#retrieving-an-sts-token
+     * @param role predefined AWS role that must be used as the baseline for allowable actions, effects, and resources
+     * @param bucket S3 bucket name
+     * @param key S3 key to grant access to
+     * @param effect policy statement effect (for example, GetObject)
+     * @param action action allowed by temporary credentials (must intersect with the policies already defined by role)
+     * @param durationSeconds duration in seconds that the credentials are valid for (900 is minumum)
+     * @return
+     */
     public static Credentials getS3Credentials(String role, String bucket, String key, Statement.Effect effect, S3Actions action, int durationSeconds) {
         String ROLE_ARN = role;
         AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.defaultClient();

--- a/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
@@ -14,11 +14,11 @@ import static spark.Spark.halt;
  */
 public class SparkUtils {
 
-    public static Object downloadFile(File file, Response res) {
+    public static Object downloadFile(File file, String filename, Response res) {
         if(file == null) halt(404, "File is null");
 
         res.raw().setContentType("application/octet-stream");
-        res.raw().setHeader("Content-Disposition", "attachment; filename=" + file.getName());
+        res.raw().setHeader("Content-Disposition", "attachment; filename=" + filename);
 
         try {
             BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(res.raw().getOutputStream());

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/AgencyController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/AgencyController.java
@@ -2,10 +2,9 @@ package com.conveyal.datatools.editor.controllers.api;
 
 import com.conveyal.datatools.editor.controllers.Base;
 import com.conveyal.datatools.editor.datastore.FeedTx;
-import com.conveyal.datatools.editor.datastore.GlobalTx;
 import com.conveyal.datatools.editor.datastore.VersionedDataStore;
 import com.conveyal.datatools.editor.models.transit.Agency;
-import com.conveyal.datatools.editor.utils.S3Utils;
+import com.conveyal.datatools.common.utils.S3Utils;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import org.slf4j.Logger;

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/RouteController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/RouteController.java
@@ -1,9 +1,7 @@
 package com.conveyal.datatools.editor.controllers.api;
 
-import com.conveyal.datatools.editor.utils.S3Utils;
+import com.conveyal.datatools.common.utils.S3Utils;
 import com.conveyal.datatools.editor.datastore.FeedTx;
-import com.conveyal.datatools.manager.auth.Auth0UserProfile;
-import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import com.google.common.base.Function;

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -1,8 +1,12 @@
 package com.conveyal.datatools.editor.controllers.api;
 
+
 import com.conveyal.datatools.common.utils.SparkUtils;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.actions.S3Actions;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.conveyal.datatools.editor.controllers.Base;
-import com.conveyal.datatools.editor.datastore.FeedTx;
 import com.conveyal.datatools.editor.datastore.GlobalTx;
 import com.conveyal.datatools.editor.datastore.VersionedDataStore;
 import com.conveyal.datatools.editor.jobs.ProcessGtfsSnapshotExport;
@@ -12,11 +16,11 @@ import com.conveyal.datatools.editor.models.transit.Stop;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.auth.Auth0UserProfile;
 import com.conveyal.datatools.manager.controllers.api.FeedSourceController;
-import com.conveyal.datatools.manager.controllers.api.FeedVersionController;
 import com.conveyal.datatools.manager.models.FeedDownloadToken;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.JsonViews;
+import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import org.mapdb.Fun;
 import org.mapdb.Fun.Tuple2;
@@ -32,6 +36,7 @@ import java.util.List;
 import spark.Request;
 import spark.Response;
 
+import static com.conveyal.datatools.common.utils.S3Utils.getS3Credentials;
 import static com.conveyal.datatools.common.utils.SparkUtils.downloadFile;
 import static spark.Spark.*;
 
@@ -68,6 +73,7 @@ public class SnapshotController {
                     snapshots = gtx.snapshots.values();
                 }
                 else {
+                    FeedSource feedSource = FeedSourceController.requestFeedSource(req, FeedSource.get(feedId), "view");
                     snapshots = gtx.snapshots.subMap(new Tuple2(feedId, null), new Tuple2(feedId, Fun.HI)).values();
                 }
 
@@ -226,7 +232,7 @@ public class SnapshotController {
     }
 
     /** Export a snapshot as GTFS */
-    public static Object exportSnapshot (Request req, Response res) {
+    public static Object getSnapshotToken(Request req, Response res) {
         String id = req.params("id");
         Tuple2<String, Integer> decodedId;
         FeedDownloadToken token;
@@ -238,20 +244,47 @@ public class SnapshotController {
         }
 
         GlobalTx gtx = VersionedDataStore.getGlobalTx();
-        Snapshot local;
+        Snapshot snapshot;
+        String filename;
+        String key;
         try {
             if (!gtx.snapshots.containsKey(decodedId)) {
                 halt(404);
                 return null;
             }
-
-            local = gtx.snapshots.get(decodedId);
-            token = new FeedDownloadToken(local);
-            token.save();
+            snapshot = gtx.snapshots.get(decodedId);
+            filename = snapshot.feedId + "_" + snapshot.snapshotTime + ".zip";
+            key = "snapshots/" + filename;
+            FeedSource feedSource = FeedSourceController.requestFeedSource(req, FeedSource.get(snapshot.feedId), "view");
         } finally {
             gtx.rollbackIfOpen();
         }
-        return token;
+        if (DataManager.getConfigPropertyAsText("application.data.use_s3_storage").equals("true")) {
+            if (!FeedStore.s3Client.doesObjectExist(DataManager.feedBucket, key)) {
+                File file;
+                try {
+                    File tDir = new File(System.getProperty("java.io.tmpdir"));
+                    file = File.createTempFile(snapshot.feedId + "_" + snapshot.snapshotTime, ".zip");
+                    file.deleteOnExit();
+                    writeSnapshotAsGtfs(snapshot.id, file);
+                    try {
+                        LOG.info("Uploading snapshot to S3 {}", key);
+                        FeedStore.s3Client.putObject(new PutObjectRequest(
+                                DataManager.feedBucket, key, file));
+                        file.delete();
+                    } catch (AmazonServiceException ase) {
+                        LOG.error("Error uploading snapshot to S3", ase);
+                    }
+                } catch (Exception e) {
+                    LOG.error("Unable to create temp file for snapshot", e);
+                }
+            }
+            return getS3Credentials(DataManager.awsRole, DataManager.feedBucket, key, Statement.Effect.Allow, S3Actions.GetObject, 900);
+        } else {
+            token = new FeedDownloadToken(snapshot);
+            token.save();
+            return token;
+        }
     }
 
     /** Write snapshot to disk as GTFS */
@@ -314,13 +347,14 @@ public class SnapshotController {
         try {
             file = File.createTempFile("snapshot", ".zip");
             writeSnapshotAsGtfs(snapshot.id, file);
+            file.deleteOnExit();
         } catch (Exception e) {
             e.printStackTrace();
             String message = "Unable to create temp file for snapshot";
             LOG.error(message);
         }
         token.delete();
-        return downloadFile(file, res);
+        return downloadFile(file, snapshot.feedId + "_" + snapshot.snapshotTime + ".zip", res);
     }
     public static void register (String apiPrefix) {
         get(apiPrefix + "secure/snapshot/:id", SnapshotController::getSnapshot, json::write);
@@ -330,7 +364,7 @@ public class SnapshotController {
         post(apiPrefix + "secure/snapshot/import", SnapshotController::importSnapshot, json::write);
         put(apiPrefix + "secure/snapshot/:id", SnapshotController::updateSnapshot, json::write);
         post(apiPrefix + "secure/snapshot/:id/restore", SnapshotController::restoreSnapshot, json::write);
-        get(apiPrefix + "secure/snapshot/:id/downloadtoken", SnapshotController::exportSnapshot, json::write);
+        get(apiPrefix + "secure/snapshot/:id/downloadtoken", SnapshotController::getSnapshotToken, json::write);
         delete(apiPrefix + "secure/snapshot/:id", SnapshotController::deleteSnapshot, json::write);
 
         get(apiPrefix + "downloadsnapshot/:token", SnapshotController::downloadSnapshotWithToken);

--- a/src/main/java/com/conveyal/datatools/editor/utils/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/editor/utils/S3Utils.java
@@ -5,6 +5,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.conveyal.datatools.manager.DataManager;
@@ -58,16 +59,9 @@ public class S3Utils {
         }
 
         try {
-//            LOG.info("Uploading route branding to S3");
-            // Upload file to s3
-            AWSCredentials creds;
-
-            // default credentials providers, e.g. IAM role
-            creds = new DefaultAWSCredentialsProviderChain().getCredentials();
-
             String keyName = "branding/" + id + extension;
             url = "https://s3.amazonaws.com/" + s3Bucket + "/" + keyName;
-            AmazonS3 s3client = new AmazonS3Client(creds);
+            AmazonS3 s3client = AmazonS3ClientBuilder.defaultClient();
             s3client.putObject(new PutObjectRequest(
                     s3Bucket, keyName, tempFile)
                     // grant public read

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -63,6 +63,7 @@ public class DataManager {
     public static GTFSCache gtfsCache;
 
     public static String feedBucket;
+    public static String awsRole;
     public static String bucketFolder;
 
 //    public final AmazonS3Client s3Client;
@@ -96,6 +97,7 @@ public class DataManager {
         }
 
         feedBucket = getConfigPropertyAsText("application.data.gtfs_s3_bucket");
+        awsRole = getConfigPropertyAsText("application.data.aws_role");
         bucketFolder = FeedStore.s3Prefix;
 
         if (useS3) {

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -84,7 +84,7 @@ public class DataManager {
         if (getConfigProperty("application.port") != null) {
             port(Integer.parseInt(getConfigPropertyAsText("application.port")));
         }
-        useS3 = getConfigPropertyAsText("application.data.use_s3_storage").equals("true");
+        useS3 = "true".equals(getConfigPropertyAsText("application.data.use_s3_storage"));
 
         // initialize map of auto fetched projects
         for (Project p : Project.getAll()) {

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -271,11 +271,11 @@ public class DataManager {
     }
 
     public static boolean isModuleEnabled(String moduleName) {
-        return "true".equals(getConfigPropertyAsText("modules." + moduleName + ".enabled"));
+        return hasConfigProperty("modules." + moduleName) && "true".equals(getConfigPropertyAsText("modules." + moduleName + ".enabled"));
     }
 
     public static boolean isExtensionEnabled(String extensionName) {
-        return "true".equals(getConfigPropertyAsText("extensions." + extensionName + ".enabled"));
+        return hasConfigProperty("extensions." + extensionName) && "true".equals(getConfigPropertyAsText("extensions." + extensionName + ".enabled"));
     }
 
     private static void registerExternalResources() {

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0Connection.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0Connection.java
@@ -26,9 +26,9 @@ public class Auth0Connection {
         if(token == null) {
             halt(401, "Could not find authorization token");
         }
-
+        Auth0UserProfile profile = null;
         try {
-            Auth0UserProfile profile = getUserProfile(token);
+            profile = getUserProfile(token);
             req.attribute("user", profile);
         }
         catch(Exception e) {
@@ -82,6 +82,17 @@ public class Auth0Connection {
         in.close();
 
         ObjectMapper m = new ObjectMapper();
-        return m.readValue(response.toString(), Auth0UserProfile.class);
+        Auth0UserProfile profile = null;
+        String userString = response.toString();
+        try {
+            profile = m.readValue(userString, Auth0UserProfile.class);
+        }
+        catch(Exception e) {
+            Object json = m.readValue(userString, Object.class);
+            System.out.println(m.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+            LOG.warn("Could not verify user", e);
+            halt(401, "Could not verify user");
+        }
+        return profile;
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsApiController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsApiController.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools.manager.controllers.api;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -28,7 +29,7 @@ public class GtfsApiController {
     public static final Logger LOG = LoggerFactory.getLogger(GtfsApiController.class);
     public static String feedBucket;
     public static FeedUpdater feedUpdater;
-    private static AmazonS3Client s3 = new AmazonS3Client();
+    private static AmazonS3 s3 = AmazonS3ClientBuilder.defaultClient();
     public static String bucketFolder;
     public static void register (String apiPrefix) throws IOException {
 

--- a/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
+++ b/src/main/java/com/conveyal/datatools/manager/extensions/mtc/MtcFeedResource.java
@@ -12,6 +12,7 @@ import com.conveyal.datatools.manager.models.ExternalFeedSourceProperty;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.Project;
+import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -195,16 +196,6 @@ public class MtcFeedResource implements ExternalFeedResource {
 
         if(s3Bucket == null) return;
 
-        AWSCredentials creds;
-        if (this.s3CredentialsFilename != null) {
-            creds = new ProfileCredentialsProvider(this.s3CredentialsFilename, "default").getCredentials();
-            LOG.info("Writing to S3 using supplied credentials file");
-        }
-        else {
-            // default credentials providers, e.g. IAM role
-            creds = new DefaultAWSCredentialsProviderChain().getCredentials();
-        }
-
         ExternalFeedSourceProperty agencyIdProp =
                 ExternalFeedSourceProperty.find(feedVersion.getFeedSource(), this.getResourceType(), "AgencyId");
 
@@ -218,8 +209,7 @@ public class MtcFeedResource implements ExternalFeedResource {
 
         File file = feedVersion.getGtfsFile();
 
-        AmazonS3 s3client = new AmazonS3Client(creds);
-        s3client.putObject(new PutObjectRequest(
+        FeedStore.s3Client.putObject(new PutObjectRequest(
                 s3Bucket, keyName, file));
     }
 

--- a/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/DeployJob.java
@@ -10,6 +10,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
 
 import java.io.File;
@@ -27,6 +28,7 @@ import java.util.Map;
 
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.manager.models.Deployment;
+import com.conveyal.datatools.manager.persistence.FeedStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,24 +151,13 @@ public class DeployJob extends MonitorableJob {
             LOG.info("Uploading deployment {} to s3", deployment.name);
 
             try {
-                AWSCredentials creds;
-                if (this.s3CredentialsFilename != null) {
-                    creds = new ProfileCredentialsProvider(this.s3CredentialsFilename, "default").getCredentials();
-                }
-                else {
-                    // default credentials providers, e.g. IAM role
-                    creds = new DefaultAWSCredentialsProviderChain().getCredentials();
-                }
-
-                TransferManager tx = new TransferManager(creds);
+                TransferManager tx = TransferManagerBuilder.standard().withS3Client(FeedStore.s3Client).build();
                 String key = bundlePrefix + deployment.getProject().id + "/" + deployment.name + ".zip";
                 final Upload upload = tx.upload(this.s3Bucket, key, temp);
 
-                upload.addProgressListener(new ProgressListener() {
-                    public void progressChanged(ProgressEvent progressEvent) {
-                        synchronized (status) {
-                            status.percentUploaded = upload.getProgress().getPercentTransferred();
-                        }
+                upload.addProgressListener((ProgressListener) progressEvent -> {
+                    synchronized (status) {
+                        status.percentUploaded = upload.getProgress().getPercentTransferred();
                     }
                 });
 
@@ -175,10 +166,9 @@ public class DeployJob extends MonitorableJob {
 
                 // copy to [name]-latest.zip
                 String copyKey = bundlePrefix + deployment.getProject().id + "/" + deployment.getProject().name.toLowerCase() + "-latest.zip";
-                AmazonS3 s3client = new AmazonS3Client(creds);
                 CopyObjectRequest copyObjRequest = new CopyObjectRequest(
                         this.s3Bucket, key, this.s3Bucket, copyKey);
-                s3client.copyObject(copyObjRequest);
+                FeedStore.s3Client.copyObject(copyObjRequest);
 
             } catch (AmazonClientException|InterruptedException e) {
                 LOG.error("Error uploading deployment bundle to S3");


### PR DESCRIPTION
Backend changes for #1.

This PR, in conjunction with catalogueglobal/datatools-ui#4, allows for the direct download of feeds from s3 using Temporary Security Credentials (new role in AWS IAM must be created).  Rather than using tokens to download feeds (a method which is still used when not using s3), this approach issues credentials to users for the requested feed, which are then used by the client to download the feed from s3.