### PR TITLE
fix(editor): fix memory leaks on editor db transactions

### DIFF
--- a/src/main/java/com/conveyal/datatools/editor/controllers/Base.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/Base.java
@@ -26,6 +26,7 @@ public class Base {
         mod.addSerializer(GtfsRouteType.class, new JacksonSerializers.GtfsRouteTypeSerializer());
         mod.addDeserializer(TripDirection.class, new JacksonSerializers.TripDirectionDeserializer());
         mod.addSerializer(TripDirection.class, new JacksonSerializers.TripDirectionSerializer());
+        mapper.getSerializerProvider().setNullKeySerializer(new JacksonSerializers.MyDtoNullKeySerializer());
         mapper.registerModule(mod);
         mapper.registerModule(new GeoJsonModule());
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/AgencyController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/AgencyController.java
@@ -46,7 +46,7 @@ public class AgencyController {
             e.printStackTrace();
             halt(400);
         } finally {
-            if (tx != null) tx.rollback();
+            if (tx != null) tx.rollbackIfOpen();
         }
         return json;
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/CalendarController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/CalendarController.java
@@ -77,6 +77,10 @@ public class CalendarController {
                 return ret;
             }
             else {
+                /**
+                 * put values into a new ArrayList to avoid returning MapDB BTreeMap
+                 * (and possible access error once transaction is closed)
+                 */
                 Collection<ServiceCalendar> cals = new ArrayList<>(tx.calendars.values());
                 for (ServiceCalendar c : cals) {
                     c.addDerivedInfo(tx);

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/CalendarController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/CalendarController.java
@@ -1,18 +1,14 @@
 package com.conveyal.datatools.editor.controllers.api;
 
-import com.conveyal.datatools.common.utils.SparkUtils;
 import com.conveyal.datatools.editor.datastore.FeedTx;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.Sets;
 import com.conveyal.datatools.editor.controllers.Base;
 import com.conveyal.datatools.editor.datastore.VersionedDataStore;
 import com.conveyal.datatools.editor.models.transit.ScheduleException;
 import com.conveyal.datatools.editor.models.transit.ServiceCalendar;
 import com.conveyal.datatools.editor.models.transit.ServiceCalendar.ServiceCalendarForPattern;
-import com.conveyal.datatools.editor.models.transit.Trip;
 import org.mapdb.Fun;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,35 +19,35 @@ import spark.Response;
 import static com.conveyal.datatools.common.utils.SparkUtils.formatJSON;
 import static spark.Spark.*;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 
 public class CalendarController {
-    public static JsonManager<Calendar> json =
+    public static final JsonManager<Calendar> json =
             new JsonManager<>(Calendar.class, JsonViews.UserInterface.class);
     private static final Logger LOG = LoggerFactory.getLogger(CalendarController.class);
+
     public static Object getCalendar(Request req, Response res) {
         String id = req.params("id");
         String feedId = req.queryParams("feedId");
         String patternId = req.queryParams("patternId");
 
         if (feedId == null) {
-            feedId = req.session().attribute("feedId");
-        }
-
-        if (feedId == null) {
             halt(400);
         }
 
-        final FeedTx tx = VersionedDataStore.getFeedTx(feedId);
+        FeedTx tx = null;
 
         try {
+            tx = VersionedDataStore.getFeedTx(feedId);
             if (id != null) {
                 if (!tx.calendars.containsKey(id)) {
                     halt(404);
-                    tx.rollback();
                 }
 
                 else {
@@ -62,54 +58,44 @@ public class CalendarController {
             }
             else if (patternId != null) {
                 if (!tx.tripPatterns.containsKey(patternId)) {
-                    tx.rollback();
                     halt(404);
                 }
 
                 Set<String> serviceCalendarIds = Sets.newHashSet();
-                for (Trip trip : tx.getTripsByPattern(patternId)) {
-                    serviceCalendarIds.add(trip.calendarId);
+                serviceCalendarIds.addAll(tx.getTripsByPattern(patternId).stream()
+                        .map(trip -> trip.calendarId)
+                        .collect(Collectors.toList()));
+
+                Collection<ServiceCalendarForPattern> ret = new HashSet<>();
+
+                for (String calendarId : serviceCalendarIds) {
+                    ServiceCalendar cal = tx.calendars.get(calendarId);
+                    Long count = tx.tripCountByPatternAndCalendar.get(new Fun.Tuple2(patternId, cal.id));
+                    if (count == null) count = 0L;
+                    ret.add(new ServiceCalendarForPattern(cal, tx.tripPatterns.get(patternId), count));
                 }
-
-                Collection<ServiceCalendarForPattern> ret =
-                        Collections2.transform(serviceCalendarIds, new Function<String, ServiceCalendarForPattern>() {
-
-                            @Override
-                            public ServiceCalendarForPattern apply(String input) {
-                                ServiceCalendar cal = tx.calendars.get(input);
-
-                                Long count = tx.tripCountByPatternAndCalendar.get(new Fun.Tuple2(patternId, cal.id));
-
-                                if (count == null) count = 0L;
-
-                                return new ServiceCalendarForPattern(cal, tx.tripPatterns.get(patternId), count);
-                            }
-
-                        });
-
                 return ret;
             }
             else {
-                Collection<ServiceCalendar> cals = tx.calendars.values();
+                Collection<ServiceCalendar> cals = new ArrayList<>(tx.calendars.values());
                 for (ServiceCalendar c : cals) {
                     c.addDerivedInfo(tx);
                 }
                 return cals;
             }
-
-            tx.rollback();
         } catch (HaltException e) {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
-            tx.rollback();
             e.printStackTrace();
             halt(400);
+        } finally {
+            if (tx != null) tx.rollback();
         }
         return null;
     }
 
-    public static Object createCalendar(Request req, Response res) {
+    public static ServiceCalendar createCalendar(Request req, Response res) {
         ServiceCalendar cal;
         FeedTx tx = null;
 
@@ -122,21 +108,20 @@ public class CalendarController {
 
             if (req.session().attribute("feedId") != null && !req.session().attribute("feedId").equals(cal.feedId))
                 halt(400);
-            
+
             tx = VersionedDataStore.getFeedTx(cal.feedId);
-            
+
             if (tx.calendars.containsKey(cal.id)) {
-                tx.rollback();
                 halt(400);
             }
-            
+
             // check if gtfsServiceId is specified, if not create from DB id
             if(cal.gtfsServiceId == null) {
                 cal.gtfsServiceId = "CAL_" + cal.id.toString();
             }
-            
+
             cal.addDerivedInfo(tx);
-            
+
             tx.calendars.put(cal.id, cal);
             tx.commit();
 
@@ -145,14 +130,15 @@ public class CalendarController {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
-            if (tx != null) tx.rollback();
             e.printStackTrace();
             halt(400);
+        } finally {
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }
 
-    public static Object updateCalendar(Request req, Response res) {
+    public static ServiceCalendar updateCalendar(Request req, Response res) {
         ServiceCalendar cal;
         FeedTx tx = null;
 
@@ -163,70 +149,75 @@ public class CalendarController {
                 halt(400);
             }
 
-            if (req.session().attribute("feedId") != null && !req.session().attribute("feedId").equals(cal.feedId))
-                halt(400);
-
             tx = VersionedDataStore.getFeedTx(cal.feedId);
-            
+
             if (!tx.calendars.containsKey(cal.id)) {
-                tx.rollback();
                 halt(400);
             }
-            
+
             // check if gtfsServiceId is specified, if not create from DB id
             if(cal.gtfsServiceId == null) {
                 cal.gtfsServiceId = "CAL_" + cal.id.toString();
             }
-            
+
             cal.addDerivedInfo(tx);
-            
             tx.calendars.put(cal.id, cal);
-            
-            Object json = Base.toJson(cal, false);
-            
             tx.commit();
 
-            return json;
+            return cal;
         } catch (HaltException e) {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
-            if (tx != null) tx.rollback();
             e.printStackTrace();
             halt(400);
+        } finally {
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }
 
-    public static Object deleteCalendar(Request req, Response res) {
+    public static ServiceCalendar deleteCalendar(Request req, Response res) {
         String id = req.params("id");
         String feedId = req.queryParams("feedId");
 
-        FeedTx tx = VersionedDataStore.getFeedTx(feedId);
+        FeedTx tx = null;
 
-        if (id == null || !tx.calendars.containsKey(id)) {
-            tx.rollback();
-            halt(404);
+        try {
+            tx = VersionedDataStore.getFeedTx(feedId);
+
+            if (id == null || !tx.calendars.containsKey(id)) {
+                halt(404);
+            }
+
+            // we just don't let you delete calendars unless there are no trips on them
+            Long count = tx.tripCountByCalendar.get(id);
+            if (count != null && count > 0) {
+                halt(400, formatJSON("Cannot delete calendar that is referenced by trips.", 400));
+            }
+
+            // drop this calendar from any schedule exceptions
+            for (ScheduleException ex : tx.getExceptionsByCalendar(id)) {
+                ex.customSchedule.remove(id);
+                tx.exceptions.put(ex.id, ex);
+            }
+            ServiceCalendar cal = tx.calendars.get(id);
+
+            tx.calendars.remove(id);
+
+            tx.commit();
+
+            return cal;
+        } catch (HaltException e) {
+            LOG.error("Halt encountered", e);
+            throw e;
+        } catch (Exception e) {
+            e.printStackTrace();
+            halt(400);
+        } finally {
+            if (tx != null) tx.rollbackIfOpen();
         }
-
-        // we just don't let you delete calendars unless there are no trips on them
-        Long count = tx.tripCountByCalendar.get(id);
-        if (count != null && count > 0) {
-            tx.rollback();
-            halt(400, formatJSON("Cannot delete calendar that is referenced by trips.", 400));
-        }
-
-        // drop this calendar from any schedule exceptions
-        for (ScheduleException ex : tx.getExceptionsByCalendar(id)) {
-            ex.customSchedule.remove(id);
-            tx.exceptions.put(ex.id, ex);
-        }
-
-        tx.calendars.remove(id);
-
-        tx.commit();
-
-        return true; // ok();
+        return null;
     }
 
     public static void register (String apiPrefix) {

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/CalendarController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/CalendarController.java
@@ -90,7 +90,7 @@ public class CalendarController {
             e.printStackTrace();
             halt(400);
         } finally {
-            if (tx != null) tx.rollback();
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/FareController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/FareController.java
@@ -165,7 +165,7 @@ public class FareController {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
-            if (tx != null) tx.rollback();
+            if (tx != null) tx.rollbackIfOpen();
             e.printStackTrace();
             halt(400);
         } finally {

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/FareController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/FareController.java
@@ -54,6 +54,10 @@ public class FareController {
                 }
             }
             else {
+                /**
+                 * put values into a new ArrayList to avoid returning MapDB BTreeMap
+                 * (and possible access error once transaction is closed)
+                  */
                 Collection<Fare> fares = new ArrayList<>(tx.fares.values());
                 return fares;
             }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/FeedInfoController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/FeedInfoController.java
@@ -5,13 +5,9 @@ import com.conveyal.datatools.editor.datastore.FeedTx;
 import com.conveyal.datatools.editor.datastore.GlobalTx;
 import com.conveyal.datatools.editor.datastore.VersionedDataStore;
 import com.conveyal.datatools.editor.models.transit.EditorFeed;
-import com.conveyal.datatools.editor.models.transit.GtfsRouteType;
 import com.conveyal.datatools.manager.models.FeedSource;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
-import com.conveyal.gtfs.model.FeedInfo;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.HaltException;
@@ -19,11 +15,6 @@ import spark.Request;
 import spark.Response;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.time.LocalDate;
-import java.util.Iterator;
-import java.util.Map;
 
 import static spark.Spark.*;
 import static spark.Spark.delete;
@@ -33,37 +24,38 @@ import static spark.Spark.put;
  * Created by landon on 6/14/16.
  */
 public class FeedInfoController {
-    public static JsonManager<EditorFeed> json =
+    public static final JsonManager<EditorFeed> json =
             new JsonManager<>(EditorFeed.class, JsonViews.UserInterface.class);
     private static final Logger LOG = LoggerFactory.getLogger(FeedInfoController.class);
-    public static Object getFeedInfo(Request req, Response res) {
+
+    public static EditorFeed getFeedInfo(Request req, Response res) {
         String id = req.params("id");
 
         if (id == null) {
             return null;
             // TODO: return all feedInfos for project?
         }
-        GlobalTx gtx = VersionedDataStore.getGlobalTx();
-        if (!gtx.feeds.containsKey(id)) {
-            // create new EditorFeed if id exists in manager
-            if (FeedSource.get(id) != null) {
-                EditorFeed fs = new EditorFeed(id);
-                gtx.feeds.put(fs.id, fs);
-                gtx.commit();
-                try {
-                    return Base.toJson(fs, false);
-                } catch (IOException e) {
-                    e.printStackTrace();
+        GlobalTx gtx = null;
+        try {
+            gtx = VersionedDataStore.getGlobalTx();
+            if (!gtx.feeds.containsKey(id)) {
+                // create new EditorFeed if id exists in manager
+                if (FeedSource.get(id) != null) {
+                    EditorFeed fs = new EditorFeed(id);
+                    gtx.feeds.put(fs.id, fs);
+                    gtx.commit();
+                    return fs;
+                }
+                else {
+                    halt(404, "Feed id does not exist");
+                    return null;
                 }
             }
-            else {
-                gtx.rollback();
-                halt(404, "Feed id does not exist");
-                return null;
-            }
+            EditorFeed fs = gtx.feeds.get(id);
+            return fs;
+        } finally {
+            gtx.rollback();
         }
-        EditorFeed fs = gtx.feeds.get(id);
-        return fs;
     }
 
     public static Object createFeedInfo(Request req, Response res) {
@@ -72,16 +64,9 @@ public class FeedInfoController {
 
         try {
             fs = Base.mapper.readValue(req.body(), EditorFeed.class);
-//
-//            // check if gtfsAgencyId is specified, if not create from DB id
-//            if(fs.gtfsAgencyId == null) {
-//                fs.gtfsAgencyId = "AGENCY_" + fs.id;
-//            }
 
             if (gtx.feeds.containsKey(fs.id)) {
-                gtx.rollback();
                 halt(404, "Feed id already exists in editor database");
-                return null;
             }
 
             gtx.feeds.put(fs.id, fs);
@@ -92,155 +77,76 @@ public class FeedInfoController {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
-            gtx.rollbackIfOpen();
             e.printStackTrace();
             halt(404);
-            return null;
+        } finally {
+            if (gtx != null) gtx.rollbackIfOpen();
         }
+        return null;
     }
 
 
-    public static Object updateFeedInfo(Request req, Response res) throws IOException {
+    public static EditorFeed updateFeedInfo(Request req, Response res) throws IOException {
         String id = req.params("id");
 
         EditorFeed feed;
-
+        GlobalTx gtx = null;
         try {
             feed = Base.mapper.readValue(req.body(), EditorFeed.class);
-            GlobalTx gtx = VersionedDataStore.getGlobalTx();
+            gtx = VersionedDataStore.getGlobalTx();
 
             if(!gtx.feeds.containsKey(feed.id)) {
-                gtx.rollback();
                 halt(400);
-                return null;
             }
 
             gtx.feeds.put(feed.id, feed);
             gtx.commit();
 
-            return Base.toJson(feed, false);
+            return feed;
         } catch (HaltException e) {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
             e.printStackTrace();
             halt(400);
+        } finally {
+            if (gtx != null) gtx.rollbackIfOpen();
         }
         return null;
     }
 
-    public static void applyJsonToFeedInfo(EditorFeed source, String json) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode node = mapper.readTree(json);
-        Iterator<Map.Entry<String, JsonNode>> fieldsIter = node.fields();
-        while (fieldsIter.hasNext()) {
-            Map.Entry<String, JsonNode> entry = fieldsIter.next();
+    /**
+     * Delete NOT ONLY feed info, but also entirely delete the record of the feed in the editor database.
+     * @param req
+     * @param res
+     * @return
+     */
+    public static Object deleteFeedInfo(Request req, Response res) {
+        String id = req.params("id");
 
-            if (entry.getValue().isNull()) {
-                continue;
+        EditorFeed feed;
+        GlobalTx gtx = null;
+        try {
+            gtx = VersionedDataStore.getGlobalTx();
+            if(!gtx.feeds.containsKey(id)) {
+                halt(400);
             }
+            feed = gtx.feeds.get(id);
+            gtx.feeds.remove(id);
+            gtx.commit();
 
-            if(entry.getKey().equals("color")) {
-                source.color = entry.getValue().asText();
-            }
-
-            if(entry.getKey().equals("defaultLat")) {
-                source.defaultLat = entry.getValue().asDouble();
-            }
-
-            if(entry.getKey().equals("defaultLon")) {
-                source.defaultLon = entry.getValue().asDouble();
-            }
-
-            if(entry.getKey().equals("routeTypeId")) {
-                source.defaultRouteType = GtfsRouteType.fromGtfs(entry.getValue().asInt());
-            }
-
-            if(entry.getKey().equals("feedPublisherName")) {
-                source.feedPublisherName = entry.getValue().asText();
-            }
-
-            if(entry.getKey().equals("feedVersion")) {
-                source.feedVersion = entry.getValue().asText();
-            }
-
-            if(entry.getKey().equals("feedPublisherUrl")) {
-                String url = entry.getValue().asText();
-                try {
-                    source.feedPublisherUrl = new URL(url);
-
-                } catch (MalformedURLException e) {
-                    halt(400, "URL '" + url + "' not valid.");
-                }
-                source.feedPublisherUrl = new URL(entry.getValue().asText());
-            }
-
-            if(entry.getKey().equals("feedLang")) {
-                source.feedLang = entry.getValue().asText();
-            }
-
-            if(entry.getKey().equals("feedStartDate")) {
-                System.out.println(entry.getValue());
-                Long seconds = entry.getValue().asLong();
-                Long days = seconds / 60 / 60 / 24;
-//                System.out.println(days);
-                try {
-                    LocalDate date = LocalDate.ofEpochDay(days);
-//                    System.out.println(date.format(DateTimeFormatter.BASIC_ISO_DATE));
-                    source.feedStartDate = date;
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    halt(400, seconds + " is not a valid date");
-                }
-            }
-
-            if(entry.getKey().equals("feedEndDate")) {
-                Long seconds = entry.getValue().asLong();
-                Long days = seconds / 60 / 60 / 24;
-                try {
-                    LocalDate date = LocalDate.ofEpochDay(days);
-                    source.feedEndDate = date;
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    halt(400, seconds + " is not a valid date");
-                }
-            }
+            return feed;
+        } catch (HaltException e) {
+            LOG.error("Halt encountered", e);
+            throw e;
+        } catch (Exception e) {
+            e.printStackTrace();
+            halt(400);
+        } finally {
+            if (gtx != null) gtx.rollbackIfOpen();
         }
+        return null;
     }
-    // TODO: deleting editor feed is handled in delete feed source?
-//    public static Object deleteFeedInfo(Request req, Response res) {
-//        String id = req.params("id");
-//        String feedId = req.queryParams("feedId");
-//        Object json = null;
-//
-//        if (feedId == null)
-//            feedId = req.session().attribute("feedId");
-//
-//        if (feedId == null) {
-//            halt(400);
-//        }
-//
-//        FeedTx tx = VersionedDataStore.getFeedTx(feedId);
-//        try {
-//            if (!tx.stops.containsKey(id)) {
-//                halt(404);
-//            }
-//
-//            if (!tx.getTripPatternsByStop(id).isEmpty()) {
-//                halt(400);
-//            }
-//
-//            FeedInfo s = tx.stops.remove(id);
-//            tx.commit();
-//            json = Base.toJson(s, false);
-//        } catch (Exception e) {
-//            halt(400);
-//            e.printStackTrace();
-//        } finally {
-//            tx.rollbackIfOpen();
-//        }
-//        return json;
-//    }
 
     public static void register (String apiPrefix) {
         get(apiPrefix + "secure/feedinfo/:id", FeedInfoController::getFeedInfo, json::write);
@@ -248,6 +154,6 @@ public class FeedInfoController {
         get(apiPrefix + "secure/feedinfo", FeedInfoController::getFeedInfo, json::write);
         post(apiPrefix + "secure/feedinfo/:id", FeedInfoController::createFeedInfo, json::write);
         put(apiPrefix + "secure/feedinfo/:id", FeedInfoController::updateFeedInfo, json::write);
-//        delete(apiPrefix + "secure/feedinfo/:id", FeedInfoController::deleteFeedInfo, json::write);
+        delete(apiPrefix + "secure/feedinfo/:id", FeedInfoController::deleteFeedInfo, json::write);
     }
 }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/FeedInfoController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/FeedInfoController.java
@@ -54,7 +54,7 @@ public class FeedInfoController {
             EditorFeed fs = gtx.feeds.get(id);
             return fs;
         } finally {
-            gtx.rollback();
+            gtx.rollbackIfOpen();
         }
     }
 

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/FeedInfoController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/FeedInfoController.java
@@ -121,7 +121,7 @@ public class FeedInfoController {
      * @param res
      * @return
      */
-    public static Object deleteFeedInfo(Request req, Response res) {
+    public static Object deleteFeedInfoAndEntireFeedEntryInEditor(Request req, Response res) {
         String id = req.params("id");
 
         EditorFeed feed;
@@ -154,6 +154,6 @@ public class FeedInfoController {
         get(apiPrefix + "secure/feedinfo", FeedInfoController::getFeedInfo, json::write);
         post(apiPrefix + "secure/feedinfo/:id", FeedInfoController::createFeedInfo, json::write);
         put(apiPrefix + "secure/feedinfo/:id", FeedInfoController::updateFeedInfo, json::write);
-        delete(apiPrefix + "secure/feedinfo/:id", FeedInfoController::deleteFeedInfo, json::write);
+        delete(apiPrefix + "secure/feedinfo/:id", FeedInfoController::deleteFeedInfoAndEntireFeedEntryInEditor, json::write);
     }
 }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/RouteController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/RouteController.java
@@ -73,7 +73,7 @@ public class RouteController {
             e.printStackTrace();
             halt(400);
         } finally {
-            if (tx != null) tx.rollback();
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/RouteController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/RouteController.java
@@ -59,6 +59,10 @@ public class RouteController {
                 return route;
             }
             else {
+                /**
+                 * put values into a new HashSet to avoid returning MapDB BTreeMap
+                 * (and possible access error once transaction is closed)
+                 */
                 Set<Route> ret = new HashSet<>(tx.routes.values());
 
                 for (Route r : ret) {

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/ScheduleExceptionController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/ScheduleExceptionController.java
@@ -191,12 +191,24 @@ public class ScheduleExceptionController {
         if (feedId == null) {
             halt(400);
         }
-        FeedTx tx = VersionedDataStore.getFeedTx(feedId);
-        ScheduleException ex = tx.exceptions.get(id);
-        tx.exceptions.remove(id);
-        tx.commit();
+        FeedTx tx = null;
+        try {
+            tx = VersionedDataStore.getFeedTx(feedId);
+            ScheduleException ex = tx.exceptions.get(id);
+            tx.exceptions.remove(id);
+            tx.commit();
 
-        return ex; // ok();
+            return ex; // ok();
+        } catch (HaltException e) {
+            LOG.error("Halt encountered", e);
+            throw e;
+        } catch (Exception e) {
+            e.printStackTrace();
+            halt(400);
+        } finally {
+            if (tx != null) tx.rollbackIfOpen();
+        }
+        return null;
     }
 
     public static void register (String apiPrefix) {

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -87,7 +87,7 @@ public class SnapshotController {
             LOG.error("Halt encountered", e);
             throw e;
         } finally {
-            if (gtx != null) gtx.rollback();
+            if (gtx != null) gtx.rollbackIfOpen();
         }
         return null;
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/StopController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/StopController.java
@@ -102,7 +102,7 @@ public class StopController {
             e.printStackTrace();
             halt(400);
         } finally {
-            if (tx != null) tx.rollback();
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }
@@ -306,7 +306,7 @@ public class StopController {
              halt(400);
          }
         finally {
-            if (tx != null) tx.rollback();
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/TripController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/TripController.java
@@ -79,7 +79,7 @@ public class TripController {
             e.printStackTrace();
             halt(400);
         } finally {
-            if (tx != null) tx.rollback();
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/TripPatternController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/TripPatternController.java
@@ -2,8 +2,6 @@ package com.conveyal.datatools.editor.controllers.api;
 
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
 import com.conveyal.datatools.editor.controllers.Base;
 import com.conveyal.datatools.editor.datastore.FeedTx;
 import com.conveyal.datatools.editor.datastore.VersionedDataStore;
@@ -12,7 +10,9 @@ import com.conveyal.datatools.editor.models.transit.TripPattern;
 import org.mapdb.Fun;
 import org.mapdb.Fun.Tuple2;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -26,31 +26,30 @@ import static spark.Spark.*;
 
 public class TripPatternController {
     private static final Logger LOG = LoggerFactory.getLogger(TripPatternController.class);
-    public static JsonManager<TripPattern> json =
+    public static final JsonManager<TripPattern> json =
             new JsonManager<>(TripPattern.class, JsonViews.UserInterface.class);
 
     public static Object getTripPattern(Request req, Response res) {
         String id = req.params("id");
         String routeId = req.queryParams("routeId");
         String feedId = req.queryParams("feedId");
-        Object json = null;
-
-        if (feedId == null)
-            feedId = req.session().attribute("feedId");
 
         if (feedId == null) {
             halt(400);
         }
 
-        final FeedTx tx = VersionedDataStore.getFeedTx(feedId);
+        FeedTx tx = null;
 
         try {
-
+            tx = VersionedDataStore.getFeedTx(feedId);
             if(id != null) {
                if (!tx.tripPatterns.containsKey(id))
                    halt(404);
-               else
-                   json = Base.toJson(tx.tripPatterns.get(id), false);
+               else {
+                   TripPattern tp = tx.tripPatterns.get(id);
+                   tp.addDerivedInfo(tx);
+                   return Base.toJson(tp, false);
+               }
             }
             else if (routeId != null) {
 
@@ -58,67 +57,65 @@ public class TripPatternController {
                     halt(404, "routeId '" + routeId + "' does not exist");
                 else {
                     Set<Tuple2<String, String>> tpKeys = tx.tripPatternsByRoute.subSet(new Tuple2(routeId, null), new Tuple2(routeId, Fun.HI));
-
-                    Collection<TripPattern> patts = Collections2.transform(tpKeys, new Function<Tuple2<String, String>, TripPattern>() {
-
-                        @Override
-                        public TripPattern apply(Tuple2<String, String> input) {
-                            return tx.tripPatterns.get(input.b);
-                        }
-                    });
-
-                    json = Base.toJson(patts, false);
+                    Set<TripPattern> patts = new HashSet<>();
+                    for (Tuple2<String, String> key : tpKeys) {
+                        TripPattern tp = tx.tripPatterns.get(key.b);
+                        tp.addDerivedInfo(tx);
+                        patts.add(tp);
+                    }
+                    return patts;
                 }
             }
             else { // get all patterns
-                json = Base.toJson(tx.tripPatterns, false);
+                Collection<TripPattern> patts = new ArrayList<>(tx.tripPatterns.values());
+                return patts;
             }
-            
-            tx.rollback();
-            
         } catch (HaltException e) {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
-            tx.rollback();
             e.printStackTrace();
             halt(400);
+        } finally {
+            if (tx != null) tx.rollback();
         }
-        return json;
+        return null;
     }
 
-    public static Object createTripPattern(Request req, Response res) {
+    public static TripPattern createTripPattern(Request req, Response res) {
         TripPattern tripPattern;
-        
+        FeedTx tx = null;
+        String feedId = req.queryParams("feedId");
         try {
             tripPattern = Base.mapper.readValue(req.body(), TripPattern.class);
             
-            if (req.session().attribute("feedId") != null && !req.session().attribute("feedId").equals(tripPattern.feedId))
+            if (feedId == null)
                 halt(400);
             
             if (!VersionedDataStore.feedExists(tripPattern.feedId)) {
                 halt(400);
             }
             
-            FeedTx tx = VersionedDataStore.getFeedTx(tripPattern.feedId);
+            tx = VersionedDataStore.getFeedTx(tripPattern.feedId);
             
             if (tx.tripPatterns.containsKey(tripPattern.id)) {
-                tx.rollback();
                 halt(400);
             }
             
-            tripPattern.calcShapeDistTraveled();
+            tripPattern.calcShapeDistTraveled(tx);
             
             tx.tripPatterns.put(tripPattern.id, tripPattern);
             tx.commit();
 
-            return Base.toJson(tripPattern, false);
+            return tripPattern;
         } catch (HaltException e) {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
             e.printStackTrace();
             halt(400);
+        } finally {
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }
@@ -130,7 +127,7 @@ public class TripPatternController {
      * @param res
      * @return
      */
-    public static Object updateTripPattern(Request req, Response res) {
+    public static TripPattern updateTripPattern(Request req, Response res) {
         TripPattern tripPattern;
         FeedTx tx = null;
         try {
@@ -152,7 +149,6 @@ public class TripPatternController {
             TripPattern originalTripPattern = tx.tripPatterns.get(tripPattern.id);
             
             if(originalTripPattern == null) {
-                tx.rollback();
                 halt(400);
             }
 
@@ -171,29 +167,33 @@ public class TripPatternController {
             try {
                 TripPattern.reconcilePatternStops(originalTripPattern, tripPattern, tx);
             } catch (IllegalStateException e) {
-                tx.rollback();
                 LOG.info("Could not save trip pattern", e);
                 halt(400);
             }
             
-            tripPattern.calcShapeDistTraveled();
+            tripPattern.calcShapeDistTraveled(tx);
             
             tx.tripPatterns.put(tripPattern.id, tripPattern);
+
+            // return trip pattern with derived info
+            tripPattern.addDerivedInfo(tx);
+
             tx.commit();
 
-            return Base.toJson(tripPattern, false);
+            return tripPattern;
         } catch (HaltException e) {
             LOG.error("Halt encountered", e);
             throw e;
         } catch (Exception e) {
-            if (tx != null) tx.rollback();
             e.printStackTrace();
             halt(400);
+        } finally {
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }
 
-    public static Object deleteTripPattern(Request req, Response res) {
+    public static TripPattern deleteTripPattern(Request req, Response res) {
         String id = req.params("id");
         String feedId = req.queryParams("feedId");
 
@@ -204,26 +204,39 @@ public class TripPatternController {
             halt(400);
         }
 
-        FeedTx tx = VersionedDataStore.getFeedTx(feedId);
+        FeedTx tx = null;
 
         try {
+            tx = VersionedDataStore.getFeedTx(feedId);
+
+            if (!tx.tripPatterns.containsKey(id)) {
+                halt(404);
+            }
+
             // first zap all trips on this trip pattern
             for (Trip trip : tx.getTripsByPattern(id)) {
                 tx.trips.remove(trip.id);
             }
-
+            TripPattern tp = tx.tripPatterns.get(id);
             tx.tripPatterns.remove(id);
             tx.commit();
+            return tp;
+        } catch (HaltException e) {
+            LOG.error("Halt encountered", e);
+            throw e;
+        } catch (Exception e) {
+            e.printStackTrace();
+            halt(400);
         } finally {
-            tx.rollbackIfOpen();
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }
 
     public static void register (String apiPrefix) {
         get(apiPrefix + "secure/trippattern/:id", TripPatternController::getTripPattern, json::write);
-        options(apiPrefix + "secure/trippattern", (q, s) -> "");
         get(apiPrefix + "secure/trippattern", TripPatternController::getTripPattern, json::write);
+
         post(apiPrefix + "secure/trippattern", TripPatternController::createTripPattern, json::write);
         put(apiPrefix + "secure/trippattern/:id", TripPatternController::updateTripPattern, json::write);
         delete(apiPrefix + "secure/trippattern/:id", TripPatternController::deleteTripPattern, json::write);

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/TripPatternController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/TripPatternController.java
@@ -77,7 +77,7 @@ public class TripPatternController {
             e.printStackTrace();
             halt(400);
         } finally {
-            if (tx != null) tx.rollback();
+            if (tx != null) tx.rollbackIfOpen();
         }
         return null;
     }

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/TripPatternController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/TripPatternController.java
@@ -67,6 +67,11 @@ public class TripPatternController {
                 }
             }
             else { // get all patterns
+
+                /**
+                 * put values into a new ArrayList to avoid returning MapDB BTreeMap
+                 * (and possible access error once transaction is closed)
+                 */
                 Collection<TripPattern> patts = new ArrayList<>(tx.tripPatterns.values());
                 return patts;
             }

--- a/src/main/java/com/conveyal/datatools/editor/jobs/ProcessGtfsSnapshotExport.java
+++ b/src/main/java/com/conveyal/datatools/editor/jobs/ProcessGtfsSnapshotExport.java
@@ -139,7 +139,6 @@ public class ProcessGtfsSnapshotExport implements Runnable {
                                 }
                             }
                         }
-
                         feed.services.put(gtfsService.service_id, gtfsService);
                     }
                 }
@@ -208,26 +207,11 @@ public class ProcessGtfsSnapshotExport implements Runnable {
                         if (pattern.shape != null && !pattern.useStraightLineDistances)
                             gtfsTrip.shape_id = pattern.id;
 
+                        // prefer trip wheelchair boarding value if available
                         if (trip.wheelchairBoarding != null) {
-                            if (trip.wheelchairBoarding.equals(AttributeAvailabilityType.AVAILABLE))
-                                gtfsTrip.wheelchair_accessible = 1;
-
-                            else if (trip.wheelchairBoarding.equals(AttributeAvailabilityType.UNAVAILABLE))
-                                gtfsTrip.wheelchair_accessible = 2;
-
-                            else
-                                gtfsTrip.wheelchair_accessible = 0;
-
+                            gtfsTrip.wheelchair_accessible = trip.wheelchairBoarding.toGtfs();
                         } else if (route.wheelchairBoarding != null) {
-                            if (route.wheelchairBoarding.equals(AttributeAvailabilityType.AVAILABLE))
-                                gtfsTrip.wheelchair_accessible = 1;
-
-                            else if (route.wheelchairBoarding.equals(AttributeAvailabilityType.UNAVAILABLE))
-                                gtfsTrip.wheelchair_accessible = 2;
-
-                            else
-                                gtfsTrip.wheelchair_accessible = 0;
-
+                            gtfsTrip.wheelchair_accessible = route.wheelchairBoarding.toGtfs();
                         }
 
                         feed.trips.put(gtfsTrip.trip_id, gtfsTrip);

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/AttributeAvailabilityType.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/AttributeAvailabilityType.java
@@ -3,5 +3,16 @@ package com.conveyal.datatools.editor.models.transit;
 public enum AttributeAvailabilityType {
     UNKNOWN,
     AVAILABLE,
-    UNAVAILABLE
+    UNAVAILABLE;
+
+    public int toGtfs () {
+        switch (this) {
+            case AVAILABLE:
+                return 1;
+            case UNAVAILABLE:
+                return 2;
+            default: // if value is UNKNOWN or missing
+                return 0;
+        }
+    }
 }

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/Fare.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/Fare.java
@@ -1,7 +1,6 @@
 package com.conveyal.datatools.editor.models.transit;
 
 import com.conveyal.datatools.editor.models.Model;
-import com.conveyal.gtfs.model.FareAttribute;
 import com.conveyal.gtfs.model.FareRule;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.collect.Lists;
@@ -27,7 +26,7 @@ public class Fare extends Model implements Cloneable, Serializable {
     public Integer transferDuration;
     public List<FareRule> fareRules  = Lists.newArrayList();
 
-    public Fare() {};
+    public Fare() {}
 
     public Fare(com.conveyal.gtfs.model.FareAttribute fare, List<com.conveyal.gtfs.model.FareRule> rules, EditorFeed feed) {
         this.gtfsFareId = fare.fare_id;

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/Route.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/Route.java
@@ -1,6 +1,5 @@
 package com.conveyal.datatools.editor.models.transit;
 
-import com.conveyal.datatools.editor.datastore.VersionedDataStore;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.conveyal.datatools.editor.datastore.FeedTx;
@@ -128,8 +127,6 @@ public class Route extends Model implements Cloneable, Serializable {
         ret.route_short_name = routeShortName;
         ret.route_text_color = routeTextColor;
         ret.route_type = gtfsRouteType.toGtfs();
-        // TODO also handle HVT types here
-        //ret.route_type = mapGtfsRouteType(routeTypeId);
         try {
             ret.route_url = routeUrl == null ? null : new URL(routeUrl);
         } catch (MalformedURLException e) {

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/ScheduleException.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/ScheduleException.java
@@ -83,14 +83,14 @@ public class ScheduleException extends Model implements Cloneable, Serializable 
      * Represents a desire about what service should be like on a particular day.
      * For example, run Sunday service on Presidents' Day, or no service on New Year's Day.
      */
-    public static enum ExemplarServiceDescriptor {
-        MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY, NO_SERVICE, CUSTOM, SWAP;
+    public enum ExemplarServiceDescriptor {
+        MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY, NO_SERVICE, CUSTOM, SWAP
     }
 
     public ScheduleException clone () throws CloneNotSupportedException {
         ScheduleException c = (ScheduleException) super.clone();
-        c.dates = new ArrayList<LocalDate>(this.dates);
-        c.customSchedule = new ArrayList<String>(this.customSchedule);
+        c.dates = new ArrayList<>(this.dates);
+        c.customSchedule = new ArrayList<>(this.customSchedule);
         return c;
     }
 }

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/ServiceCalendar.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/ServiceCalendar.java
@@ -31,7 +31,7 @@ public class ServiceCalendar extends Model implements Cloneable, Serializable {
     public LocalDate startDate;
     public LocalDate endDate;
     
-    public ServiceCalendar() {};
+    public ServiceCalendar() {}
     
     public ServiceCalendar(Calendar calendar, EditorFeed feed) {
         this.gtfsServiceId = calendar.service_id;
@@ -208,7 +208,6 @@ public class ServiceCalendar extends Model implements Cloneable, Serializable {
 
         // note that this is not ideal as we are fetching all of the trips. however, it's not really very possible
         // with MapDB to have an index involving three tables.
-        Set<String> routeIds = Sets.newHashSet();
         Map<String, Long> tripsForRoutes = new HashMap<>();
         for (Trip trip : tx.getTripsByCalendar(this.id)) {
             if (trip == null) continue;

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/ServiceCalendar.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/ServiceCalendar.java
@@ -5,8 +5,6 @@ import com.beust.jcommander.internal.Sets;
 import com.conveyal.gtfs.model.Calendar;
 import com.conveyal.gtfs.model.Service;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
 import com.conveyal.datatools.editor.datastore.FeedTx;
 import com.conveyal.datatools.editor.models.Model;
 import java.time.LocalDate;
@@ -213,6 +211,7 @@ public class ServiceCalendar extends Model implements Cloneable, Serializable {
         Set<String> routeIds = Sets.newHashSet();
         Map<String, Long> tripsForRoutes = new HashMap<>();
         for (Trip trip : tx.getTripsByCalendar(this.id)) {
+            if (trip == null) continue;
             Long count = 0L;
 
             /**
@@ -228,16 +227,7 @@ public class ServiceCalendar extends Model implements Cloneable, Serializable {
             if (trip.routeId != null) {
                 tripsForRoutes.put(trip.routeId, count + 1);
             }
-//            routeIds.add(trip.routeId);
         }
         this.routes = tripsForRoutes;
-//        this.routes = Collections2.transform(routeIds, new Function<String, String>() {
-//
-//            @Override
-//            public String apply(String routeId) {
-//                return tx.routes.get(routeId).getName();
-//            }
-//
-//        });
     }
 }

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/Stop.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/Stop.java
@@ -116,8 +116,8 @@ public class Stop extends Model implements Cloneable, Serializable {
         ret.stop_desc = stopDesc;
         ret.stop_lat = location.getY();
         ret.stop_lon = location.getX();
-        // TODO gtfs-lib value needs to be int
-//        ret.wheelchair_boarding = wheelchairBoarding.toGtfs();
+        // TODO: gtfs-lib value needs to be int
+        ret.wheelchair_boarding = String.valueOf(wheelchairBoarding.toGtfs());
 
         if (stopName != null && !stopName.isEmpty())
             ret.stop_name = stopName;

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/TripPattern.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/TripPattern.java
@@ -10,10 +10,8 @@ import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.linearref.LinearLocation;
 import com.vividsolutions.jts.linearref.LocationIndexedLine;
-import com.conveyal.datatools.editor.datastore.VersionedDataStore;
 import com.conveyal.datatools.editor.models.Model;
 import org.geotools.referencing.GeodeticCalculator;
-import org.mapdb.Fun;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.conveyal.datatools.editor.utils.GeoUtils;
@@ -47,7 +45,7 @@ public class TripPattern extends Model implements Cloneable, Serializable {
 
     public TripDirection patternDirection;
 
-    public List<TripPatternStop> patternStops = new ArrayList<TripPatternStop>();
+    public List<TripPatternStop> patternStops = new ArrayList<>();
 
     // give the UI a little information about the content of this trip pattern
     public transient Long numberOfTrips;
@@ -72,16 +70,16 @@ public class TripPattern extends Model implements Cloneable, Serializable {
     /** add transient info for UI with number of routes, number of trips */
     public void addDerivedInfo(final FeedTx tx) {
         Collection<Trip> trips = tx.getTripsByPattern(this.id);
-        numberOfTrips = Long.valueOf(trips.size());
+        numberOfTrips = (long) trips.size();
         tripCountByCalendar = trips.stream()
                 .filter(t -> t != null && t.calendarId != null)
                 .collect(Collectors.groupingBy(t -> t.calendarId, Collectors.counting()));
     }
 
-    /**
-     * Lines showing how stops are being snapped to the shape.
-     * @return
-     */
+//    /**
+//     * Lines showing how stops are being snapped to the shape.
+//     * @return array of LineStrings showing how stops connect to shape
+//     */
 //    @JsonProperty("stopConnections")
 //    public LineString[] jsonGetStopConnections () {
 //        if (useStraightLineDistances || shape == null)
@@ -117,13 +115,9 @@ public class TripPattern extends Model implements Cloneable, Serializable {
 //
 //    }
 
-    public TripPattern()
-    {
+    public TripPattern() {}
 
-    }
-
-    public TripPattern(String name, String headsign, LineString shape, Route route)
-    {
+    public TripPattern(String name, String headsign, LineString shape, Route route) {
         this.name = name;
         this.headsign = headsign;
         this.shape = shape;
@@ -138,7 +132,7 @@ public class TripPattern extends Model implements Cloneable, Serializable {
         else
             ret.shape = null;
 
-        ret.patternStops = new ArrayList<TripPatternStop>();
+        ret.patternStops = new ArrayList<>();
 
         for (TripPatternStop ps : this.patternStops) {
             ret.patternStops.add(ps.clone());
@@ -325,6 +319,7 @@ public class TripPattern extends Model implements Cloneable, Serializable {
     }
 
     // cast generic Geometry object to LineString because jackson2-geojson library only returns generic Geometry objects
+    @JsonProperty
     public void setShape (Geometry g) {
         this.shape = (LineString) g;
     }
@@ -377,7 +372,7 @@ public class TripPattern extends Model implements Cloneable, Serializable {
         // location along the subline currently being considered
         LocationIndexedLine subIdx = shapeIdx;
 
-        LineString subShape = shape;
+        LineString subShape;
 
         double lastShapeDistTraveled = 0;
 

--- a/src/main/java/com/conveyal/datatools/editor/models/transit/TripPattern.java
+++ b/src/main/java/com/conveyal/datatools/editor/models/transit/TripPattern.java
@@ -48,7 +48,7 @@ public class TripPattern extends Model implements Cloneable, Serializable {
     public List<TripPatternStop> patternStops = new ArrayList<>();
 
     // give the UI a little information about the content of this trip pattern
-    public transient Long numberOfTrips;
+    public transient int numberOfTrips;
     public transient Map<String, Long> tripCountByCalendar;
 
 
@@ -70,7 +70,7 @@ public class TripPattern extends Model implements Cloneable, Serializable {
     /** add transient info for UI with number of routes, number of trips */
     public void addDerivedInfo(final FeedTx tx) {
         Collection<Trip> trips = tx.getTripsByPattern(this.id);
-        numberOfTrips = (long) trips.size();
+        numberOfTrips = trips.size();
         tripCountByCalendar = trips.stream()
                 .filter(t -> t != null && t.calendarId != null)
                 .collect(Collectors.groupingBy(t -> t.calendarId, Collectors.counting()));


### PR DESCRIPTION
A number of model classes had getters that created transactions that were never rolled back.  This
moves those into addDerivedInfo functions.

fixes #14