### PR TITLE
Run application with no auth for development

### DIFF
--- a/configurations/default/env.yml.tmp
+++ b/configurations/default/env.yml.tmp
@@ -2,6 +2,7 @@ AUTH0_CLIENT_ID: your-auth0-client-id
 AUTH0_DOMAIN: your-auth0-domain
 AUTH0_SECRET: your-auth0-secret
 AUTH0_TOKEN: your-auth0-token
+DISABLE_AUTH: false
 OSM_VEX: http://localhost:1000
 SPARKPOST_KEY: your-sparkpost-key
 SPARKPOST_EMAIL: email@example.com

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0Connection.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0Connection.java
@@ -29,7 +29,7 @@ public class Auth0Connection {
      */
     public static void checkUser(Request req) {
         // if in a development environment, assign a mock profile to request attribute
-        if (runningWithoutAuth()) {
+        if (authDisabled()) {
             req.attribute("user", new Auth0UserProfile("mock@example.com", "user_id:string"));
             return;
         }
@@ -128,11 +128,7 @@ public class Auth0Connection {
         }
     }
 
-    public static boolean runningWithoutAuth() {
-        if (DataManager.getConfigPropertyAsText("AUTH0_CLIENT_ID") == null) {
-            return true;
-        } else {
-            return false;
-        }
+    public static boolean authDisabled() {
+        return DataManager.hasConfigProperty("DISABLE_AUTH") && "true".equals(DataManager.getConfigPropertyAsText("DISABLE_AUTH"));
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0Connection.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0Connection.java
@@ -22,19 +22,28 @@ import static spark.Spark.halt;
 
 public class Auth0Connection {
     private static final Logger LOG = LoggerFactory.getLogger(Auth0Connection.class);
+
+    /**
+     * Check API request for user token.
+     * @param req Spark request object
+     */
     public static void checkUser(Request req) {
+        // if in a development environment, assign a mock profile to request attribute
+        if (runningWithoutAuth()) {
+            req.attribute("user", new Auth0UserProfile("mock@example.com", "user_id:string"));
+            return;
+        }
         String token = getToken(req);
 
         if(token == null) {
             halt(401, SparkUtils.formatJSON("Could not find authorization token", 401));
         }
-        Auth0UserProfile profile = null;
+        Auth0UserProfile profile;
         try {
             profile = getUserProfile(token);
             req.attribute("user", profile);
         }
         catch(Exception e) {
-//            e.printStackTrace();
             LOG.warn("Could not verify user", e);
             halt(401, SparkUtils.formatJSON("Could not verify user", 401));
         }
@@ -93,7 +102,7 @@ public class Auth0Connection {
             Object json = m.readValue(userString, Object.class);
             System.out.println(m.writerWithDefaultPrettyPrinter().writeValueAsString(json));
             LOG.warn("Could not verify user", e);
-            halt(401, "Could not verify user");
+            halt(401, SparkUtils.formatJSON("Could not verify user", 401));
         }
         return profile;
     }
@@ -116,6 +125,14 @@ public class Auth0Connection {
                 LOG.warn("User {} cannot edit GTFS for {}", userProfile.email, feedId);
                 halt(403, SparkUtils.formatJSON("User does not have permission to edit GTFS for feedId", 403));
             }
+        }
+    }
+
+    public static boolean runningWithoutAuth() {
+        if (DataManager.getConfigPropertyAsText("AUTH0_CLIENT_ID") == null) {
+            return true;
+        } else {
+            return false;
         }
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0UserProfile.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0UserProfile.java
@@ -69,7 +69,7 @@ public class Auth0UserProfile {
 
         @JsonIgnore
         public void setDatatoolsInfo(DatatoolsInfo datatools) {
-            if (Auth0Connection.runningWithoutAuth()) return;
+            if (Auth0Connection.authDisabled()) return;
 
             for(int i = 0; i < this.datatools.size(); i++) {
                 if (this.datatools.get(i).clientId.equals(DataManager.getConfigPropertyAsText("AUTH0_CLIENT_ID"))) {
@@ -79,7 +79,7 @@ public class Auth0UserProfile {
         }
         @JsonIgnore
         public DatatoolsInfo getDatatoolsInfo() {
-            if (Auth0Connection.runningWithoutAuth()) return null;
+            if (Auth0Connection.authDisabled()) return null;
 
             for(int i = 0; i < this.datatools.size(); i++) {
                 DatatoolsInfo dt = this.datatools.get(i);
@@ -245,7 +245,7 @@ public class Auth0UserProfile {
 
     public boolean canAdministerApplication() {
         // NOTE: user can administer application by default if running without authentication
-        if (Auth0Connection.runningWithoutAuth()) return true;
+        if (Auth0Connection.authDisabled()) return true;
 
         if(app_metadata.getDatatoolsInfo() != null && app_metadata.getDatatoolsInfo().permissions != null) {
             for(Permission permission : app_metadata.getDatatoolsInfo().permissions) {

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0UserProfile.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0UserProfile.java
@@ -1,18 +1,11 @@
 package com.conveyal.datatools.manager.auth;
 
 import com.conveyal.datatools.manager.DataManager;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by demory on 1/18/16.
@@ -24,9 +17,18 @@ public class Auth0UserProfile {
     String user_id;
     AppMetadata app_metadata;
 
-    public Auth0UserProfile() {
-    }
+    public Auth0UserProfile() {}
 
+    /**
+     * Constructor for creating a mock user (app admin) for testing environment.
+     * @param email
+     * @param user_id
+     */
+    public Auth0UserProfile(String email, String user_id) {
+        setEmail(email);
+        setUser_id(user_id);
+        setApp_metadata(new AppMetadata());
+    }
 
     public String getUser_id() {
         return user_id;
@@ -60,15 +62,15 @@ public class Auth0UserProfile {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class AppMetadata {
-        ObjectMapper mapper = new ObjectMapper();
         @JsonProperty("datatools")
         List<DatatoolsInfo> datatools;
 
-        public AppMetadata() {
-        }
+        public AppMetadata() {}
 
         @JsonIgnore
         public void setDatatoolsInfo(DatatoolsInfo datatools) {
+            if (Auth0Connection.runningWithoutAuth()) return;
+
             for(int i = 0; i < this.datatools.size(); i++) {
                 if (this.datatools.get(i).clientId.equals(DataManager.getConfigPropertyAsText("AUTH0_CLIENT_ID"))) {
                     this.datatools.set(i, datatools);
@@ -77,6 +79,8 @@ public class Auth0UserProfile {
         }
         @JsonIgnore
         public DatatoolsInfo getDatatoolsInfo() {
+            if (Auth0Connection.runningWithoutAuth()) return null;
+
             for(int i = 0; i < this.datatools.size(); i++) {
                 DatatoolsInfo dt = this.datatools.get(i);
                 if (dt.clientId.equals(DataManager.getConfigPropertyAsText("AUTH0_CLIENT_ID"))) {
@@ -95,8 +99,7 @@ public class Auth0UserProfile {
         Permission[] permissions;
         Subscription[] subscriptions;
 
-        public DatatoolsInfo() {
-        }
+        public DatatoolsInfo() {}
 
         public DatatoolsInfo(String clientId, Project[] projects, Permission[] permissions, Organization[] organizations, Subscription[] subscriptions) {
             this.clientId = clientId;
@@ -135,8 +138,7 @@ public class Auth0UserProfile {
         Permission[] permissions;
         String[] defaultFeeds;
 
-        public Project() {
-        }
+        public Project() {}
 
         public Project(String project_id, Permission[] permissions, String[] defaultFeeds) {
             this.project_id = project_id;
@@ -161,8 +163,7 @@ public class Auth0UserProfile {
         String type;
         String[] feeds;
 
-        public Permission() {
-        }
+        public Permission() {}
 
         public Permission(String type, String[] feeds) {
             this.type = type;
@@ -208,8 +209,7 @@ public class Auth0UserProfile {
         String type;
         String[] target;
 
-        public Subscription() {
-        }
+        public Subscription() {}
 
         public Subscription(String type, String[] target) {
             this.type = type;
@@ -244,6 +244,9 @@ public class Auth0UserProfile {
     }
 
     public boolean canAdministerApplication() {
+        // NOTE: user can administer application by default if running without authentication
+        if (Auth0Connection.runningWithoutAuth()) return true;
+
         if(app_metadata.getDatatoolsInfo() != null && app_metadata.getDatatoolsInfo().permissions != null) {
             for(Permission permission : app_metadata.getDatatoolsInfo().permissions) {
                 if(permission.type.equals("administer-application")) {

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/UserController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/UserController.java
@@ -243,6 +243,7 @@ public class UserController {
                 }
             }
         } else {
+            // NOTE: this condition will also occur if DISABLE_AUTH is set to true
             halt(403, SparkUtils.formatJSON("User does not have permission to access to this application", 403));
         }
 

--- a/src/main/java/com/conveyal/datatools/manager/utils/StringUtils.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/StringUtils.java
@@ -7,6 +7,6 @@ public class StringUtils {
      * @return a new name with weird letters removed/transliterated.
      */
     public static String getCleanName (String name) {
-        return name.replace(' ', '_').replaceAll("[^A-Za-z0-9_-]", "");
+        return name != null ? name.replace(' ', '_').replaceAll("[^A-Za-z0-9_-]", "") : name;
     }
 }


### PR DESCRIPTION
1. If `AUTH0_CLIENT_ID` config property is `null`, when check user is called, attach a mock user to the request (where the user would normally be constructed from the Auth0 token).
2. When any permission check is performed, short circuit this check (return `true` for `application-admin` permission).