### PR TITLE
Fix download merged project feed

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
+++ b/src/main/java/com/conveyal/datatools/common/status/MonitorableJob.java
@@ -35,7 +35,8 @@ public abstract class MonitorableJob implements Runnable {
         VALIDATE_FEED,
         FETCH_PROJECT_FEEDS,
         FETCH_SINGLE_FEED,
-        MAKE_PROJECT_PUBLIC
+        MAKE_PROJECT_PUBLIC,
+        MERGE_PROJECT_FEEDS
     }
 
     public MonitorableJob(String owner, String name, JobType type) {

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -167,7 +167,7 @@ public class FeedVersionController  {
         return true;
     }
 
-    public static Boolean createFeedVersionFromSnapshot (Request req, Response res) throws IOException, ServletException {
+    public static boolean createFeedVersionFromSnapshot (Request req, Response res) throws IOException, ServletException {
 
         Auth0UserProfile userProfile = req.attribute("user");
         // TODO: should this be edit privilege?
@@ -350,9 +350,6 @@ public class FeedVersionController  {
     /**
      * Returns credentials that a client may use to then download a feed version. Functionality
      * changes depending on whether application.data.use_s3_storage config property is true.
-     * @param req
-     * @param res
-     * @return token string or temporary S3 credentials, depending on whether feeds are stored on S3
      */
     public static Object getFeedDownloadCredentials(Request req, Response res) {
         FeedVersion version = requestFeedVersion(req, "view");

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -282,7 +282,7 @@ public class ProjectController {
 
         // if storing feeds on s3, return temporary s3 credentials for that zip file
         if (DataManager.useS3) {
-            return getS3Credentials(DataManager.awsRole, DataManager.feedBucket, "project" + project.id + ".zip", Statement.Effect.Allow, S3Actions.GetObject, 900);
+            return getS3Credentials(DataManager.awsRole, DataManager.feedBucket, "project/" + project.id + ".zip", Statement.Effect.Allow, S3Actions.GetObject, 900);
         } else {
             // when feeds are stored locally, single-use download token will still be used
             FeedDownloadToken token = new FeedDownloadToken(project);

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MergeProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MergeProjectFeedsJob.java
@@ -1,0 +1,278 @@
+package com.conveyal.datatools.manager.jobs;
+
+import com.conveyal.datatools.common.status.MonitorableJob;
+import com.conveyal.datatools.common.utils.Consts;
+import com.conveyal.datatools.common.utils.SparkUtils;
+import com.conveyal.datatools.manager.DataManager;
+import com.conveyal.datatools.manager.models.FeedSource;
+import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.datatools.manager.models.Project;
+import com.conveyal.datatools.manager.persistence.FeedStore;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import static spark.Spark.halt;
+
+/**
+ * Created by landon on 9/19/17.
+ */
+public class MergeProjectFeedsJob extends MonitorableJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MonitorableJob.class);
+    public final Project project;
+    private final Status status;
+
+    public MergeProjectFeedsJob(Project project, String owner) {
+        super(owner, "Merging project feeds for " + project.name, JobType.MERGE_PROJECT_FEEDS);
+        this.project = project;
+        this.status = new Status();
+        status.message = "Merging feeds...";
+    }
+
+    @Override
+    public Status getStatus() {
+        synchronized (status) {
+            return status.clone();
+        }
+    }
+
+    @Override
+    public void handleStatusEvent(Map statusMap) {
+
+    }
+
+    @Override
+    public void run() {
+        // get feed sources in project
+        Collection<FeedSource> feeds = project.getProjectFeedSources();
+
+        // create temp merged zip file to add feed content to
+        File mergedFile = null;
+        try {
+            mergedFile = File.createTempFile(project.id + "-merged", ".zip");
+            mergedFile.deleteOnExit();
+
+        } catch (IOException e) {
+            LOG.error("Could not create temp file");
+            e.printStackTrace();
+            halt(400, SparkUtils.formatJSON("Unknown error while merging feeds.", 400));
+        }
+
+        // create the zipfile
+        ZipOutputStream out;
+        try {
+            out = new ZipOutputStream(new FileOutputStream(mergedFile));
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        LOG.info("Created project merge file: " + mergedFile.getAbsolutePath());
+
+        // map of feed versions to table entries contained within version's GTFS
+        Map<FeedSource, ZipFile> feedSourceMap = new HashMap<>();
+
+        // collect zipFiles for each feedSource before merging tables
+        for (FeedSource fs : feeds) {
+            // check if feed source has version (use latest)
+            FeedVersion version = fs.getLatest();
+            if (version == null) {
+                LOG.info("Skipping {} because it has no feed versions", fs.name);
+                continue;
+            }
+            // modify feed version to use prepended feed id
+            LOG.info("Adding {} feed to merged zip", fs.name);
+            try {
+                File file = version.getGtfsFile();
+                if (file == null) {
+                    LOG.error("No file exists for {}", version.id);
+                    continue;
+                }
+                ZipFile zipFile = new ZipFile(file);
+                feedSourceMap.put(fs, zipFile);
+            } catch(Exception e) {
+                e.printStackTrace();
+                LOG.error("Zipfile for version {} not found", version.id);
+            }
+        }
+
+        // loop through GTFS tables
+        int numberOfTables = DataManager.gtfsConfig.size();
+        for(int i = 0; i < numberOfTables; i++) {
+            JsonNode tableNode = DataManager.gtfsConfig.get(i);
+            byte[] tableOut = mergeTables(tableNode, feedSourceMap);
+
+            // if at least one feed has the table, include it
+            if (tableOut != null) {
+
+                String tableName = tableNode.get("name").asText();
+                synchronized (status) {
+                    status.message = "Merging " + tableName;
+                    status.percentComplete = Math.round((double) i / numberOfTables * 10000d) / 100d;
+                }
+                // create entry for zip file
+                ZipEntry tableEntry = new ZipEntry(tableName);
+                try {
+                    out.putNextEntry(tableEntry);
+                    LOG.info("Writing {} to merged feed", tableName);
+                    out.write(tableOut);
+                    out.closeEntry();
+                } catch (IOException e) {
+                    LOG.error("Error writing to table {}", tableName);
+                    e.printStackTrace();
+                }
+            }
+        }
+        try {
+            out.close();
+        } catch (IOException e) {
+            LOG.error("Error closing zip file");
+            e.printStackTrace();
+        }
+        synchronized (status) {
+            status.message = "Saving merged feed.";
+            status.percentComplete = 95.0;
+        }
+        // Store the project merged zip locally or on s3
+        if (DataManager.useS3) {
+            FeedStore.s3Client.putObject(DataManager.feedBucket, project.id + ".zip", mergedFile);
+        } else {
+            try {
+                FeedVersion.feedStore.newFeed(project.id + ".zip", new FileInputStream(mergedFile), null);
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
+                LOG.error("Could not store feed for project {}", project.id);
+            }
+        }
+        // delete temp file
+        mergedFile.delete();
+
+        synchronized (status) {
+            status.message = "Merged feed created successfully.";
+            status.completed = true;
+            status.percentComplete = 100.0;
+        }
+        jobFinished();
+    }
+
+    /**
+     * Merge the specified table for multiple GTFS feeds.
+     * @param tableNode tableNode to merge
+     * @param feedSourceMap map of feedSources to zipFiles from which to extract the .txt tables
+     * @return single merged table for feeds
+     */
+    private static byte[] mergeTables(JsonNode tableNode, Map<FeedSource, ZipFile> feedSourceMap) {
+
+        String tableName = tableNode.get("name").asText();
+        ByteArrayOutputStream tableOut = new ByteArrayOutputStream();
+
+        ArrayNode fieldsNode = (ArrayNode) tableNode.get("fields");
+        List<String> headers = new ArrayList<>();
+        for (int i = 0; i < fieldsNode.size(); i++) {
+            JsonNode fieldNode = fieldsNode.get(i);
+            String fieldName = fieldNode.get("name").asText();
+            Boolean notInSpec = fieldNode.has("datatools") && fieldNode.get("datatools").asBoolean();
+            if (notInSpec) {
+                fieldsNode.remove(i);
+            }
+            headers.add(fieldName);
+        }
+
+        try {
+            // write headers to table
+            tableOut.write(String.join(",", headers).getBytes());
+            tableOut.write("\n".getBytes());
+
+            // iterate over feed source to zipfile map
+            for ( Map.Entry<FeedSource, ZipFile> mapEntry : feedSourceMap.entrySet()) {
+                FeedSource fs = mapEntry.getKey();
+                ZipFile zipFile = mapEntry.getValue();
+                final Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                while (entries.hasMoreElements()) {
+                    final ZipEntry entry = entries.nextElement();
+                    if(tableName.equals(entry.getName())) {
+                        LOG.info("Adding {} table for {}", entry.getName(), fs.name);
+
+                        InputStream inputStream = zipFile.getInputStream(entry);
+
+                        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
+                        String line = in.readLine();
+                        String[] fields = line.split(",");
+
+                        List<String> fieldList = Arrays.asList(fields);
+
+
+                        // iterate over rows in table
+                        while((line = in.readLine()) != null) {
+                            String[] newValues = new String[fieldsNode.size()];
+                            String[] values = line.split(Consts.COLUMN_SPLIT, -1);
+                            if (values.length == 1) {
+                                LOG.warn("Found blank line. Skipping...");
+                                continue;
+                            }
+                            for(int v = 0; v < fieldsNode.size(); v++) {
+                                JsonNode fieldNode = fieldsNode.get(v);
+                                String fieldName = fieldNode.get("name").asText();
+
+                                // get index of field from GTFS spec as it appears in feed
+                                int index = fieldList.indexOf(fieldName);
+                                String val = "";
+                                try {
+                                    index = fieldList.indexOf(fieldName);
+                                    if(index != -1) {
+                                        val = values[index];
+                                    }
+                                } catch (ArrayIndexOutOfBoundsException e) {
+                                    LOG.warn("Index {} out of bounds for file {} and feed {}", index, entry.getName(), fs.name);
+                                    continue;
+                                }
+
+                                String fieldType = fieldNode.get("inputType").asText();
+
+                                // if field is a gtfs identifier, prepend with feed id/name
+                                if (fieldType.contains("GTFS") && !val.isEmpty()) {
+                                    newValues[v] = fs.name + ":" + val;
+                                }
+                                else {
+                                    newValues[v] = val;
+                                }
+                            }
+                            String newLine = String.join(",", newValues);
+
+                            // write line to table (plus new line char)
+                            tableOut.write(newLine.getBytes());
+                            tableOut.write("\n".getBytes());
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            LOG.error("Error merging feed sources: {}", feedSourceMap.keySet().stream().map(fs -> fs.name).collect(Collectors.toList()).toString());
+            halt(400, SparkUtils.formatJSON("Error merging feed sources", 400, e));
+        }
+        return tableOut.toByteArray();
+    }
+}

--- a/src/main/java/com/conveyal/datatools/manager/jobs/MergeProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/MergeProjectFeedsJob.java
@@ -157,7 +157,9 @@ public class MergeProjectFeedsJob extends MonitorableJob {
         }
         // Store the project merged zip locally or on s3
         if (DataManager.useS3) {
-            FeedStore.s3Client.putObject(DataManager.feedBucket, project.id + ".zip", mergedFile);
+            String s3Key = "project/" + project.id + ".zip";
+            FeedStore.s3Client.putObject(DataManager.feedBucket, s3Key, mergedFile);
+            LOG.info("Storing merged project feed at s3://{}/{}", DataManager.feedBucket, s3Key);
         } else {
             try {
                 FeedVersion.feedStore.newFeed(project.id + ".zip", new FileInputStream(mergedFile), null);

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedVersion.java
@@ -71,7 +71,7 @@ public class FeedVersion extends Model implements Serializable {
     public static final Logger LOG = LoggerFactory.getLogger(FeedVersion.class);
     public static final String validationSubdir = "validation/";
     static DataStore<FeedVersion> versionStore = new DataStore<>("feedversions");
-    private static FeedStore feedStore = new FeedStore();
+    public static FeedStore feedStore = new FeedStore();
 
     static {
         // set up indexing on feed versions by feed source, indexed by <FeedSource ID, version>


### PR DESCRIPTION
### Problem
The "download merged feed for project" feature previously was run synchronously within the API controller rather than with the "heavy executor" designed to handle large jobs asynchronously.  Recently, we discovered with NYSDOT that this method was not performing properly (presumably because of the large number of feeds included therein).

### Solution
Nothing fancy.  This PR moves the merge feed code into a `MonitorableJob` so that the UI will receive progress updates and is accompanied by a PR in catalogueglobal/datatools-ui.  It also creates some additional controllers to handle the token creation/delivery to the UI (modeled after FeedVersion and Snapshot downloads).