### PR TITLE
Remove trip direction serializer/deserializer

### DIFF
--- a/src/main/java/com/conveyal/datatools/editor/controllers/Base.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/Base.java
@@ -24,8 +24,6 @@ public class Base {
         mod.addSerializer(LocalDate.class, new JacksonSerializers.LocalDateSerializer());
         mod.addDeserializer(GtfsRouteType.class, new JacksonSerializers.GtfsRouteTypeDeserializer());
         mod.addSerializer(GtfsRouteType.class, new JacksonSerializers.GtfsRouteTypeSerializer());
-        mod.addDeserializer(TripDirection.class, new JacksonSerializers.TripDirectionDeserializer());
-        mod.addSerializer(TripDirection.class, new JacksonSerializers.TripDirectionSerializer());
         mapper.getSerializerProvider().setNullKeySerializer(new JacksonSerializers.MyDtoNullKeySerializer());
         mapper.registerModule(mod);
         mapper.registerModule(new GeoJsonModule());

--- a/src/main/java/com/conveyal/datatools/editor/utils/JacksonSerializers.java
+++ b/src/main/java/com/conveyal/datatools/editor/utils/JacksonSerializers.java
@@ -169,9 +169,9 @@ public class JacksonSerializers {
         }
 
         @Override
-        public void serialize(GtfsRouteType gtfsRouteType, JsonGenerator jgen,
+        public void serialize(GtfsRouteType gtfsRouteType, JsonGenerator jsonGenerator,
                               SerializerProvider arg2) throws IOException {
-            jgen.writeNumber(gtfsRouteType.toGtfs());
+            jsonGenerator.writeNumber(gtfsRouteType.toGtfs());
         }
     }
 
@@ -205,34 +205,6 @@ public class JacksonSerializers {
         public void serialize(Object nullKey, JsonGenerator jsonGenerator, SerializerProvider unused)
                 throws IOException {
             jsonGenerator.writeFieldName("");
-        }
-    }
-
-    /** serialize GtfsRouteType as GTFS integer value */
-    public static class TripDirectionSerializer extends StdScalarSerializer<TripDirection> {
-        private static final long serialVersionUID = -5149227247056620599L;
-
-        public TripDirectionSerializer() {
-            super(TripDirection.class, false);
-        }
-
-        @Override
-        public void serialize(TripDirection gtfsRouteType, JsonGenerator jgen,
-                              SerializerProvider arg2) throws IOException {
-            jgen.writeNumber(gtfsRouteType.toGtfs());
-        }
-    }
-
-    /** serialize GTFS integer value  to TripDirection */
-    public static class TripDirectionDeserializer extends StdScalarDeserializer<TripDirection> {
-        private static final long serialVersionUID = 2351921879598816469L;
-
-        public TripDirectionDeserializer () { super(TripDirection.class); }
-
-        @Override
-        public TripDirection deserialize(JsonParser jp,
-                                         DeserializationContext arg1) throws IOException {
-            return TripDirection.fromGtfs(jp.getValueAsInt());
         }
     }
 


### PR DESCRIPTION
According to #41, there was an issue deserializing/serializing pattern direction values from the A/B enum values to the 0/1 GTFS values.  There is no need to deserialize into JSON with the 0/1 values, so this PR removes all of that activity.

This PR has a corresponding PR in catalogueglobal/datatools-ui#28