### PR TITLE
Use cache for Transport network to manage memory consumption

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -15,6 +15,7 @@ import com.conveyal.datatools.manager.extensions.transitland.TransitLandFeedReso
 import com.conveyal.datatools.common.status.MonitorableJob;
 import com.conveyal.datatools.manager.models.Project;
 import com.conveyal.datatools.manager.persistence.FeedStore;
+import com.conveyal.datatools.manager.persistence.TransportNetworkCache;
 import com.conveyal.datatools.manager.utils.CorsFilter;
 import com.conveyal.gtfs.api.ApiMain;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -44,7 +45,7 @@ import static spark.Spark.*;
 
 public class DataManager {
 
-    public static final Logger LOG = LoggerFactory.getLogger(DataManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DataManager.class);
 
     public static JsonNode config;
     public static JsonNode serverConfig;
@@ -61,6 +62,7 @@ public class DataManager {
     public final static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
+    public static final TransportNetworkCache transportNetworkCache = new TransportNetworkCache();
 
     // heavy executor should contain long-lived CPU-intensive tasks (e.g., feed loading/validation)
     public static Executor heavyExecutor = Executors.newFixedThreadPool(4); // Runtime.getRuntime().availableProcessors()

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -65,6 +65,7 @@ public class FeedVersionController  {
             new JsonManager<FeedVersion>(FeedVersion.class, JsonViews.UserInterface.class);
     private static Set<String> networkBuildInProgress = new HashSet<>();
     private static Set<String> networkReadInProgress = new HashSet<>();
+    private static Map<String, Long> networkCacheQueue = new HashMap();
 
     /**
      * Grab this feed version.
@@ -261,6 +262,40 @@ public class FeedVersionController  {
                 }
             } else {
                 // TransportNetwork has not been read before and a cache load has not been triggered.
+                // TODO: add logic that keeps transport networks from being evicted while being used (below code checks load time).
+//                // This check is performed because the loading cache does not evict items even if they have expired.
+//                // This is explained here: https://github.com/google/guava/wiki/CachesExplained#when-does-cleanup-happen
+//                String waitMessage = "Sorry, isochrones for this feed are not available at the moment. Please wait approximately ";
+//                long cacheDurationInMillis = DataManager.transportNetworkCache.timeUnit.toMillis(
+//                        DataManager.transportNetworkCache.duration);
+//                long timeSinceEarliestLoad = DataManager.transportNetworkCache.getTimeSinceEarliestLoad();
+//                if (DataManager.transportNetworkCache.isAtCapacity() &&
+//                        timeSinceEarliestLoad < cacheDurationInMillis) {
+//                    // Only tell the requester that isochrones are unavailable if the cache is at capacity and
+//                    // no cached network has "expired" yet.
+//                    if (networkCacheQueue.containsKey(version.id)) {
+//                        long firstRequestTimestamp = networkCacheQueue.get(version.id);
+//                        long timeSinceFirstRequest = System.currentTimeMillis() - firstRequestTimestamp;
+//                        if (timeSinceFirstRequest > cacheDurationInMillis) {
+//                            // If 10 minutes has passed, remove from queue and pass through to begin loading the version
+//                            // into the cache.
+//                            networkCacheQueue.remove(version.id);
+//                        } else {
+//                            String waitTime = String.join(" ",
+//                                    String.valueOf(((double)cacheDurationInMillis - timeSinceFirstRequest) / 1000 / 60),
+//                                    DataManager.transportNetworkCache.timeUnit.toString());
+//                            halt(202, SparkUtils.formatJSON(waitMessage + waitTime, 202));
+//                        }
+//                    } else {
+//                        // Put feed version in the queue
+//                        String waitTime = String.join(" ",
+//                                String.valueOf(timeSinceEarliestLoad),
+//                                DataManager.transportNetworkCache.timeUnit.toString());
+//                        networkCacheQueue.put(version.id, System.currentTimeMillis());
+//                        halt(202, SparkUtils.formatJSON(waitMessage + waitTime, 202));
+//                    }
+//
+//                }
 
                 // Here we trigger an inputStream read on transport network file to determine if it exists
                 // (i.e., a network has already been built) and throw an exception if not.

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -63,7 +63,8 @@ public class FeedVersionController  {
     private static ObjectMapper mapper = new ObjectMapper();
     public static JsonManager<FeedVersion> json =
             new JsonManager<FeedVersion>(FeedVersion.class, JsonViews.UserInterface.class);
-    private static Set<String> readingNetworkVersionList = new HashSet<>();
+    private static Set<String> networkBuildInProgress = new HashSet<>();
+    private static Set<String> networkReadInProgress = new HashSet<>();
 
     /**
      * Grab this feed version.
@@ -226,50 +227,87 @@ public class FeedVersionController  {
     }
 
     public static JsonNode getIsochrones(Request req, Response res) {
-        FeedVersion version = requestFeedVersion(req, "view");
+        if (!DataManager.isModuleEnabled("validator")) {
+            halt(400, SparkUtils.formatJSON("Isochrone generation not enabled in this application."));
+        }
 
         Auth0UserProfile userProfile = req.attribute("user");
-        // if tn is null, check first if it's being built, else try reading in tn
-        if (version.transportNetwork == null) {
-            buildOrReadTransportNetwork(version, userProfile);
-        }
-        else {
+        FeedVersion version = requestFeedVersion(req, "view");
+        TransportNetwork transportNetwork = buildOrReadTransportNetwork(version, userProfile);
+        if (transportNetwork != null) {
             // remove version from list of reading network
-            if (readingNetworkVersionList.contains(version.id)) {
-                readingNetworkVersionList.remove(version.id);
+            if (networkBuildInProgress.contains(version.id)) {
+                networkBuildInProgress.remove(version.id);
             }
             AnalystClusterRequest clusterRequest = buildProfileRequest(req);
-            return getRouterResult(version.transportNetwork, clusterRequest);
+            return getRouterResult(transportNetwork, clusterRequest);
+        } else {
+            halt(202, SparkUtils.formatJSON("Reading transport network, please try again later."));
         }
         return null;
     }
 
-    private static void buildOrReadTransportNetwork(FeedVersion version, Auth0UserProfile userProfile) {
-        InputStream is = null;
-        try {
-            if (!readingNetworkVersionList.contains(version.id)) {
-                is = new FileInputStream(version.getTransportNetworkPath());
-                readingNetworkVersionList.add(version.id);
+    public static TransportNetwork buildOrReadTransportNetwork(FeedVersion version, Auth0UserProfile userProfile) {
+            if (DataManager.transportNetworkCache.containsTransportNetwork(version.id)) {
+                // Simplest case. Network has already been loaded in cache, so we just return it.
                 try {
-//                    version.transportNetwork = TransportNetwork.read(is);
-                    ReadTransportNetworkJob rtnj = new ReadTransportNetworkJob(version, userProfile.getUser_id());
-                    DataManager.heavyExecutor.execute(rtnj);
+                    if (networkReadInProgress.contains(version.id)) {
+                        networkReadInProgress.remove(version.id);
+                    }
+                    return DataManager.transportNetworkCache.getTransportNetwork(version.id);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    LOG.error("Unknown error accessing transport network.", e);
+                    halt(400, SparkUtils.formatJSON("Unknown error accessing transport network."));
+                }
+            } else {
+                // TransportNetwork has not been read before and a cache load has not been triggered.
+
+                // Here we trigger an inputStream read on transport network file to determine if it exists
+                // (i.e., a network has already been built) and throw an exception if not.
+                if (version.getTransportNetworkPath().exists()) {
+                    if (networkBuildInProgress.contains(version.id)) {
+                        // A transport network exists, but it was just built. Remove the version from the
+                        // loads in progress list, and return the network.
+                        try {
+                            // If we get to this point, a network was recently built after an API request.
+                            TransportNetwork tn = DataManager.transportNetworkCache.getTransportNetwork(version.id);
+                            networkBuildInProgress.remove(version.id);
+                            return tn;
+                        } catch (Exception e) {
+                            LOG.error("Could not read transport network.", e);
+                            halt(400, SparkUtils.formatJSON("Could not read transport network."));
+                        }
+                    } else {
+                        // A transport network exists, but has not been read yet. Call read network job or wait for read
+                        // to finish.
+                        if (!networkReadInProgress.contains(version.id)) {
+                            networkReadInProgress.add(version.id);
+                            ReadTransportNetworkJob readTransportNetworkJob =
+                                    new ReadTransportNetworkJob(version, userProfile.getUser_id());
+
+                            DataManager.heavyExecutor.execute(readTransportNetworkJob);
+                        }
+                        // Notify user that read is in progress.
+                        halt(202, SparkUtils.formatJSON("Try again later. Reading transport network", 202));
+                    }
+                } else {
+                    // If transport network has not been built yet (i.e., file does not exist), add to builds in
+                    // progress list, and begin build job.
+                    if (!networkBuildInProgress.contains(version.id)) {
+                        LOG.warn("Transport network not found. Beginning build.");
+                        networkBuildInProgress.add(version.id);
+                        BuildTransportNetworkJob buildTransportNetworkJob =
+                                new BuildTransportNetworkJob(version, userProfile.getUser_id());
+                        ReadTransportNetworkJob readTransportNetworkJob =
+                                new ReadTransportNetworkJob(version, userProfile.getUser_id());
+                        buildTransportNetworkJob.addNextJob(readTransportNetworkJob);
+                        DataManager.heavyExecutor.execute(buildTransportNetworkJob);
+                    }
+                    // Notify user that build is in progress.
+                    halt(202, SparkUtils.formatJSON("Try again later. Building transport network", 202));
                 }
             }
-            halt(202, "Try again later. Reading transport network");
-        }
-        // Catch exception if transport network not built yet
-        catch (Exception e) {
-            if (DataManager.isModuleEnabled("validator") && !readingNetworkVersionList.contains(version.id)) {
-                LOG.warn("Transport network not found. Beginning build.", e);
-                readingNetworkVersionList.add(version.id);
-                BuildTransportNetworkJob btnj = new BuildTransportNetworkJob(version, userProfile.getUser_id());
-                DataManager.heavyExecutor.execute(btnj);
-            }
-            halt(202, "Try again later. Building transport network");
-        }
+        return null;
     }
 
     private static JsonNode getRouterResult(TransportNetwork transportNetwork, AnalystClusterRequest clusterRequest) {
@@ -280,16 +318,17 @@ public class FeedVersionController  {
         targets = transportNetwork.gridPointSet;
         StreetMode mode = StreetMode.WALK;
         final LinkedPointSet linkedTargets = targets.link(transportNetwork.streetLayer, mode);
-        RepeatedRaptorProfileRouter router = new RepeatedRaptorProfileRouter(transportNetwork, clusterRequest, linkedTargets, new TaskStatistics());
+        RepeatedRaptorProfileRouter router =
+                new RepeatedRaptorProfileRouter(transportNetwork, clusterRequest, linkedTargets, new TaskStatistics());
         ResultEnvelope result = router.route();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
-            JsonGenerator jgen = new JsonFactory().createGenerator(out);
-            jgen.writeStartObject();
-            result.avgCase.writeIsochrones(jgen);
-            jgen.writeEndObject();
-            jgen.close();
+            JsonGenerator jsonGenerator = new JsonFactory().createGenerator(out);
+            jsonGenerator.writeStartObject();
+            result.avgCase.writeIsochrones(jsonGenerator);
+            jsonGenerator.writeEndObject();
+            jsonGenerator.close();
             out.close();
             String outString = new String( out.toByteArray(), StandardCharsets.UTF_8 );
             return mapper.readTree(outString);
@@ -305,7 +344,9 @@ public class FeedVersionController  {
         Double fromLon = Double.valueOf(req.queryParams("fromLon"));
         Double toLat = Double.valueOf(req.queryParams("toLat"));
         Double toLon = Double.valueOf(req.queryParams("toLon"));
-        LocalDate date = req.queryParams("date") != null ? LocalDate.parse(req.queryParams("date"), DateTimeFormatter.ISO_LOCAL_DATE) : LocalDate.now(); // 2011-12-03
+        LocalDate date = req.queryParams("date") != null
+                ? LocalDate.parse(req.queryParams("date"), DateTimeFormatter.ISO_LOCAL_DATE)
+                : LocalDate.now(); // 2011-12-03
 
         // optional with defaults
         Integer fromTime = req.queryParams("fromTime") != null ? Integer.valueOf(req.queryParams("fromTime")) : 9 * 3600;

--- a/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/ProcessSingleFeedJob.java
@@ -45,7 +45,10 @@ public class ProcessSingleFeedJob implements Runnable {
             }
         }
 
-        // chain on a network builder job, if applicable
+        // Chain on a network builder job, if applicable
+        // Note: this writes the transport network to disk but garbage collection should take care of cleaning up the
+        // in-memory object. If the network needs to be read (e.g., to generate isochrones) that will happen with the
+        // help of DataManager.transportNetworkCache
         if(DataManager.isModuleEnabled("validator")) {
             validateJob.addNextJob(new BuildTransportNetworkJob(feedVersion, owner));
         }

--- a/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Deployment.java
@@ -382,34 +382,28 @@ public class Deployment extends Model implements Serializable {
     }
 
     // Get OSM extract
-    public static InputStream getOsmExtract(Rectangle2D bounds) {
+    public static InputStream getOsmExtract(Rectangle2D bounds) throws IOException {
         // call vex server
-        URL vexUrl = null;
+        URL vexUrl;
         try {
             vexUrl = new URL(String.format(Locale.ROOT,"%s/%.6f,%.6f,%.6f,%.6f.pbf",
                     DataManager.getConfigPropertyAsText("OSM_VEX"),
                     bounds.getMinY(), bounds.getMinX(), bounds.getMaxY(), bounds.getMaxX()));
-        } catch (MalformedURLException e1) {
-            e1.printStackTrace();
+        } catch (MalformedURLException e) {
+            LOG.error("Vex server URL is malformed.", e);
+            e.printStackTrace();
+            throw e;
         }
         LOG.info("Getting OSM extract at " + vexUrl.toString());
-        HttpURLConnection conn = null;
+        HttpURLConnection conn;
+        InputStream is;
         try {
             conn = (HttpURLConnection) vexUrl.openConnection();
-        } catch (IOException e1) {
-            e1.printStackTrace();
-        }
-        try {
             conn.connect();
-        } catch (IOException e1) {
-            e1.printStackTrace();
-        }
-
-        InputStream is = null;
-        try {
             is = conn.getInputStream();
-        } catch (IOException e1) {
-            e1.printStackTrace();
+        } catch (IOException e) {
+            LOG.error("Could not connect to vex server.", e);
+            throw e;
         }
         return is;
     }

--- a/src/main/java/com/conveyal/datatools/manager/persistence/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/TransportNetworkCache.java
@@ -10,8 +10,8 @@ import com.google.common.cache.RemovalListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -28,32 +28,38 @@ public class TransportNetworkCache {
 //    private final Weigher<String, TransportNetwork> weigher = (k, transportNetwork) ->
 //            transportNetwork.gridPointSet.featureCount();
     private final LoadingCache<String, TransportNetwork> transportNetworkCache;
-    private final Set<String> loadedTransportNetworks = new HashSet<>();
+    private final Map<String, Long> loadedTransportNetworks = new HashMap<>();
+    private static final int DEFAULT_CACHE_SIZE = 3;
+    private static final long DEFAULT_DURATION = 2;
+    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.MINUTES;
+    public final int cacheSize;
+    public final long duration;
+    public final TimeUnit timeUnit;
 
     /**
      * Listens for removal from cache (due to expiration or size restriction) and sets transportNetwork to null for GC.
      */
     private final RemovalListener<String, GTFSFeed> removalListener = removalNotification -> {
-        // Set version transportNetwork to null on removal to initiate garbage collection.
-        // FIXME: is there a better way to initiate gc?
         String feedVersionId = removalNotification.getKey();
         LOG.info("Evicting transport network. Cause: {}; ID: {}", removalNotification.getCause(), feedVersionId);
-        FeedVersion version = FeedVersion.get(feedVersionId);
         loadedTransportNetworks.remove(feedVersionId);
     };
 
-    public TransportNetworkCache () {
-         transportNetworkCache = CacheBuilder.newBuilder()
-                 // we use SoftReferenced values because we have the constraint that we don't want more than one
-                 // copy of a particular TransportNetwork object around; that would mean multiple MapDBs are pointing
-                 // at the same file, which is bad.
-                 // TODO: should we be using soft values?
+    public TransportNetworkCache (int cacheSize, long duration, TimeUnit timeUnit) {
+        this.cacheSize = cacheSize;
+        this.duration = duration;
+        this.timeUnit = timeUnit;
+        transportNetworkCache = CacheBuilder.newBuilder()
+                // we use SoftReferenced values because we have the constraint that we don't want more than one
+                // copy of a particular TransportNetwork object around; that would mean multiple MapDBs are pointing
+                // at the same file, which is bad.
+                // TODO: should we be using soft values?
                 .softValues()
                 .expireAfterAccess(10, TimeUnit.MINUTES)
-                 // TODO: Use maximumWeight instead of using maximumSize for better resource consumption estimate?
-//            .maximumWeight(100000)
-//            .weigher(weigher)
-                .maximumSize(3)
+                // TODO: Use maximumWeight instead of using maximumSize for better resource consumption estimate?
+//                .maximumWeight(100000)
+//                .weigher(weigher)
+                .maximumSize(cacheSize)
                 .removalListener(removalListener)
                 .build(new CacheLoader() {
                     @Override
@@ -73,12 +79,16 @@ public class TransportNetworkCache {
                 });
     }
 
+    public TransportNetworkCache () {
+         this(DEFAULT_CACHE_SIZE, DEFAULT_DURATION, DEFAULT_TIME_UNIT);
+    }
+
     /**
      * Wraps get method on cache to handle any exceptions.
      */
     public TransportNetwork getTransportNetwork (String feedVersionId) throws ExecutionException {
         try {
-            loadedTransportNetworks.add(feedVersionId);
+            loadedTransportNetworks.put(feedVersionId, System.currentTimeMillis());
             TransportNetwork tn = transportNetworkCache.get(feedVersionId);
             return tn;
         } catch (Exception e) {
@@ -89,6 +99,20 @@ public class TransportNetworkCache {
     }
 
     public boolean containsTransportNetwork (String feedVersionId) {
-        return loadedTransportNetworks.contains(feedVersionId);
+        return loadedTransportNetworks.containsKey(feedVersionId);
+    }
+
+    public boolean isAtCapacity () {
+        return cacheSize == loadedTransportNetworks.size();
+    }
+
+    /**
+     * Calculates the time since the earliest active transport network was loaded into the cache, or returns
+     * Long.MAX_VALUE if the cache is empty.
+     */
+    public long getTimeSinceEarliestLoad() {
+        return loadedTransportNetworks.size() > 0
+                ? loadedTransportNetworks.values().stream().min(Long::compare).get() - System.currentTimeMillis()
+                : Long.MAX_VALUE;
     }
 }

--- a/src/main/java/com/conveyal/datatools/manager/persistence/TransportNetworkCache.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/TransportNetworkCache.java
@@ -1,0 +1,94 @@
+package com.conveyal.datatools.manager.persistence;
+
+import com.conveyal.datatools.manager.models.FeedVersion;
+import com.conveyal.gtfs.GTFSFeed;
+import com.conveyal.r5.transit.TransportNetwork;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This cache manages r5 TransportNetworks that are associated with FeedVersions in the application. There is a
+ * TransportNetworkCache in r5, but it functions in a manner specific to analysis, so we need a special class here.
+ *
+ * WARNING: this is not necessarily built for scalable use of isochrone generation in the application, but rather as an
+ * experimental approach to quickly generate isochrones for a GTFS feed.
+ */
+public class TransportNetworkCache {
+    private static final Logger LOG = LoggerFactory.getLogger(TransportNetworkCache.class);
+
+//    private final Weigher<String, TransportNetwork> weigher = (k, transportNetwork) ->
+//            transportNetwork.gridPointSet.featureCount();
+    private final LoadingCache<String, TransportNetwork> transportNetworkCache;
+    private final Set<String> loadedTransportNetworks = new HashSet<>();
+
+    /**
+     * Listens for removal from cache (due to expiration or size restriction) and sets transportNetwork to null for GC.
+     */
+    private final RemovalListener<String, GTFSFeed> removalListener = removalNotification -> {
+        // Set version transportNetwork to null on removal to initiate garbage collection.
+        // FIXME: is there a better way to initiate gc?
+        String feedVersionId = removalNotification.getKey();
+        LOG.info("Evicting transport network. Cause: {}; ID: {}", removalNotification.getCause(), feedVersionId);
+        FeedVersion version = FeedVersion.get(feedVersionId);
+        loadedTransportNetworks.remove(feedVersionId);
+    };
+
+    public TransportNetworkCache () {
+         transportNetworkCache = CacheBuilder.newBuilder()
+                 // we use SoftReferenced values because we have the constraint that we don't want more than one
+                 // copy of a particular TransportNetwork object around; that would mean multiple MapDBs are pointing
+                 // at the same file, which is bad.
+                 // TODO: should we be using soft values?
+                .softValues()
+                .expireAfterAccess(10, TimeUnit.MINUTES)
+                 // TODO: Use maximumWeight instead of using maximumSize for better resource consumption estimate?
+//            .maximumWeight(100000)
+//            .weigher(weigher)
+                .maximumSize(3)
+                .removalListener(removalListener)
+                .build(new CacheLoader() {
+                    @Override
+                    public TransportNetwork load(Object key) throws Exception {
+                        // Thanks, java, for making me use a cast here. If I put generic arguments to new CacheLoader
+                        // due to type erasure it can't be sure I'm using types correctly.
+                        FeedVersion version = FeedVersion.get((String) key);
+                        if (version != null) {
+                            return version.buildOrReadTransportNetwork();
+                        } else {
+                            LOG.error("Version does not exist for id {}", key);
+                            // This throws a CacheLoader$InvalidCacheLoadException
+                            return null;
+                        }
+//                    return FeedVersionController.buildOrReadTransportNetwork(FeedVersion.get((String) key), null);
+                    }
+                });
+    }
+
+    /**
+     * Wraps get method on cache to handle any exceptions.
+     */
+    public TransportNetwork getTransportNetwork (String feedVersionId) throws ExecutionException {
+        try {
+            loadedTransportNetworks.add(feedVersionId);
+            TransportNetwork tn = transportNetworkCache.get(feedVersionId);
+            return tn;
+        } catch (Exception e) {
+            LOG.error("Could not read or build transport network for {}", feedVersionId);
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    public boolean containsTransportNetwork (String feedVersionId) {
+        return loadedTransportNetworks.contains(feedVersionId);
+    }
+}


### PR DESCRIPTION
This PR fixes the `validator` module, which turns on the generation of r5 TransportNetworks.  Previously, each transport network created for a FeedVersion was attached to a  transient field on that FeedVersion and there was no limit to how many of these could exist in memory.

This PR creates a new class [`TransportNetworkCache`](https://github.com/catalogueglobal/datatools-server/blob/transport-network-cache/src/main/java/com/conveyal/datatools/manager/persistence/TransportNetworkCache.java) to manage these transport networks, not to be confused with r5's `TransportNetworkCache`, which is primarily in use for Conveyal Analysis.  

The cache is set up to have a max size and expire cached items after ten minutes.  When a user requests isochrones via the Accessibility tab in the feed version summary, [`FeedVersionController::buildOrReadTransportNetwork`](https://github.com/catalogueglobal/datatools-server/blob/transport-network-cache/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java#L251) handles the tiered logic about whether to build the network, read the network, or fulfill the request (including all of the halts that go along with that logic).