### PR TITLE
Move HTTP layer of GraphQL GTFS API into datatools-server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,8 +185,8 @@
 
         <dependency>
             <groupId>com.conveyal</groupId>
-            <artifactId>gtfs-api</artifactId>
-            <version>2.0.0</version>
+            <artifactId>gtfs-lib</artifactId>
+            <version>3.2.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>3.2.0-SNAPSHOT</version>
+            <version>3.2.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -18,7 +18,7 @@ import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.CorsFilter;
 import com.conveyal.gtfs.GTFS;
-import com.conveyal.gtfs.api.GraphQLMain;
+import com.conveyal.gtfs.GraphQLMain;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -74,27 +74,21 @@ public class DataManager {
     public static String awsRole;
     public static String bucketFolder;
 
-//    public final AmazonS3Client s3Client;
     public static boolean useS3;
     public static final String API_PREFIX = "/api/manager/";
     // TODO: move gtfs-api routes to gtfs path and add auth
-    // private static final String GTFS_API_PREFIX = API_PREFIX + "gtfs/";
     private static final String GTFS_API_PREFIX = API_PREFIX;
     public static final String EDITOR_API_PREFIX = "/api/editor/";
     public static final String publicPath = "(" + DataManager.API_PREFIX + "|" + DataManager.EDITOR_API_PREFIX + ")public/.*";
     public static final String DEFAULT_ENV = "configurations/default/env.yml";
     public static final String DEFAULT_CONFIG = "configurations/default/server.yml";
-//    public static FeedStore feedStore;
     public static DataSource GTFS_DATA_SOURCE;
-//    public static Persistence persistence;
 
     public static void main(String[] args) throws IOException {
 
         // load config
         loadConfig(args);
 
-        // FIXME: initialize feedStore here instaed of FeedVersion?
-//        feedStore = new FeedStore();
         // FIXME: hack to statically load FeedStore
         LOG.info(FeedStore.class.getSimpleName());
 
@@ -114,7 +108,7 @@ public class DataManager {
         awsRole = getConfigPropertyAsText("application.data.aws_role");
         bucketFolder = FeedStore.s3Prefix;
 
-        // initialize GTFS GraphQL API service
+        // Initialize GTFS GraphQL API service
         GraphQLMain.initialize(GTFS_DATA_SOURCE, API_PREFIX);
         LOG.info("Initialized gtfs-api at localhost:port{}", API_PREFIX);
 

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsApiController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/GtfsApiController.java
@@ -6,8 +6,6 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.conveyal.datatools.manager.DataManager;
 import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.conveyal.datatools.manager.jobs.FeedUpdater;
-import com.conveyal.gtfs.api.ApiMain;
-import com.conveyal.gtfs.api.Routes;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +15,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -71,7 +68,7 @@ public class GtfsApiController {
         }
 
         // set gtfs-api routes with apiPrefix
-        Routes.routes(apiPrefix);
+        // FIXME this no longer compiles Routes.routes(apiPrefix);
     }
 
     /**
@@ -127,7 +124,7 @@ public class GtfsApiController {
                     newTags.put(feedId, eTag);
 
                     // initiate load of feed source into API with retrieve call
-                    ApiMain.getFeedSource(feedId);
+                    // FIXME this no longer compiles ApiMain.getFeedSource(feedId);
                 } catch (Exception e) {
                     LOG.warn("Could not load feed " + keyName, e);
                 }

--- a/src/main/java/com/conveyal/gtfs/CorsFilter.java
+++ b/src/main/java/com/conveyal/gtfs/CorsFilter.java
@@ -1,0 +1,40 @@
+package com.conveyal.gtfs;
+
+/**
+ * Created by demory on 9/2/16.
+ */
+
+import spark.Filter;
+import spark.Request;
+import spark.Response;
+import spark.Spark;
+
+import java.util.HashMap;
+
+/**
+ * Really simple helper for enabling CORS in a spark application;
+ */
+
+public final class CorsFilter {
+
+    private static final HashMap<String, String> corsHeaders = new HashMap<String, String>();
+
+    static {
+        corsHeaders.put("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE,OPTIONS");
+        corsHeaders.put("Access-Control-Allow-Origin", "*");
+        corsHeaders.put("Access-Control-Allow-Headers", "Content-Type,Authorization,X-Requested-With,Content-Length,Accept,Origin,");
+        corsHeaders.put("Access-Control-Allow-Credentials", "true");
+    }
+
+    public final static void apply() {
+        Filter filter = new Filter() {
+            @Override
+            public void handle(Request request, Response response) throws Exception {
+                corsHeaders.forEach((key, value) -> {
+                    response.header(key, value);
+                });
+            }
+        };
+        Spark.after(filter);
+    }
+}

--- a/src/main/java/com/conveyal/gtfs/GraphQLController.java
+++ b/src/main/java/com/conveyal/gtfs/GraphQLController.java
@@ -1,0 +1,90 @@
+package com.conveyal.gtfs;
+
+import com.conveyal.gtfs.graphql.GTFSGraphQL;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+import graphql.introspection.IntrospectionQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+import spark.Response;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static spark.Spark.halt;
+
+/**
+ * This Spark Controller contains methods to provide HTTP responses to GraphQL queries, including a query for the
+ * GraphQL schema.
+ */
+public class GraphQLController {
+    // todo shared objectmapper
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final Logger LOG = LoggerFactory.getLogger(com.conveyal.gtfs.GraphQLController.class);
+
+    /**
+     * A Spark Controller that responds to a GraphQL query in HTTP GET query parameters.
+     */
+    public static Object get (Request request, Response response) {
+        String varsJson = request.queryParams("variables");
+        String queryJson = request.queryParams("query");
+        return doQuery(varsJson, queryJson, response);
+    }
+
+    /**
+     * A Spark Controller that responds to a GraphQL query in an HTTP POST body.
+     */
+    public static Object post (Request req, Response response) {
+        JsonNode node = null;
+        try {
+            node = mapper.readTree(req.body());
+        } catch (IOException e) {
+            LOG.warn("Error processing POST body JSON", e);
+            halt(400, "Malformed JSON");
+        }
+        // FIXME converting String to JSON nodes and back to string, then re-parsing to Map.
+        String vars = node.get("variables").asText();
+        String query = node.get("query").asText();
+        return doQuery(vars, query, response);
+    }
+
+    private static Object doQuery (String varsJson, String queryJson, Response response) {
+        long startTime = System.currentTimeMillis();
+        if (varsJson == null && queryJson == null) {
+            return GTFSGraphQL.getGraphQl().execute(IntrospectionQuery.INTROSPECTION_QUERY).getData();
+        }
+        try {
+            Map<String, Object> variables = mapper.readValue(varsJson, new TypeReference<Map<String, Object>>(){});
+            ExecutionResult result = GTFSGraphQL.getGraphQl().execute(queryJson, null, null, variables);
+            List<GraphQLError> errs = result.getErrors();
+            if (!errs.isEmpty()) {
+                response.status(400);
+                return errs;
+            } else {
+                long endTime = System.currentTimeMillis();
+                LOG.info("Query took {} msec", endTime - startTime);
+                return result.getData();
+            }
+        } catch (IOException e) {
+            LOG.warn("Error processing variable JSON", e);
+            halt(404, "Malformed JSON");
+        }
+        return null;
+    }
+
+
+    /**
+     * A Spark Controller that returns the GraphQL schema.
+     */
+    public static Object getSchema (Request req, Response res) {
+        return GTFSGraphQL.getGraphQl().execute(IntrospectionQuery.INTROSPECTION_QUERY).getData();
+    }
+
+
+}

--- a/src/main/java/com/conveyal/gtfs/GraphQLMain.java
+++ b/src/main/java/com/conveyal/gtfs/GraphQLMain.java
@@ -1,0 +1,63 @@
+package com.conveyal.gtfs;
+
+import com.conveyal.gtfs.graphql.GTFSGraphQL;
+import spark.ResponseTransformer;
+
+import javax.sql.DataSource;
+
+import static spark.Spark.get;
+import static spark.Spark.post;
+
+/**
+ * Test main method to set up a new-style (as of June 2017) GraphQL API
+ *
+ * What we're trying to provide is this:
+ * The queries that analysis-ui makes are at https://github.com/conveyal/analysis-ui/blob/dev/lib/graphql/query.js ; note that feeds are wrapped in bundles in analysis-ui (we wrap the GTFS API types)
+ * GraphQL queries for datatools-ui are at https://github.com/catalogueglobal/datatools-ui/blob/dev/lib/gtfs/util/graphql.js.
+ *
+ * We will eventually want to replace some of the REST-ish endpoints in datatools-ui, including:
+ * stops/routes by bounding box
+ * stop/routes by text string search (route_long_name/route_short_name, stop_name/stop_id/stop_code)
+ * Feeds - to get a list of the feed_ids that have been loaded into the gtfs-api
+ *
+ * Here are some sample database URLs
+ * H2_FILE_URL = "jdbc:h2:file:~/test-db"; // H2 memory does not seem faster than file
+ * SQLITE_FILE_URL = "jdbc:sqlite:/Users/abyrd/test-db";
+ * POSTGRES_LOCAL_URL = "jdbc:postgresql://localhost/catalogue";
+ */
+public class GraphQLMain {
+
+    private static final ResponseTransformer JSON_TRANSFORMER = new JsonTransformer();
+
+    public static final DataSource dataSource = null; // deprecated, just here to make this project compile.
+
+    /**
+     * @param args to use the local postgres database, jdbc:postgresql://localhost/gtfs
+     */
+    public static void main (String[] args) {
+        String databaseUrl = args[0];
+        String apiPrefix = "/";
+        if (args.length > 1) {
+            apiPrefix = args[1];
+        }
+        DataSource dataSource = GTFS.createDataSource(databaseUrl, null, null);
+        initialize(dataSource, apiPrefix);
+        CorsFilter.apply();
+    }
+
+    /**
+     * DataSource created with GTFS::createDataSource (see main() for example)
+     * API prefix should begin and end with "/", e.g. "/api/"
+     */
+    public static void initialize (DataSource dataSource, String apiPrefix) {
+        GTFSGraphQL.initialize(dataSource);
+        // Can we just pass in reference objectMapper::writeValueAsString?
+        // Why does jsonTransformer have mix-ins?
+        get(apiPrefix + "graphql", GraphQLController::get, JSON_TRANSFORMER);
+        post(apiPrefix + "graphql", GraphQLController::post, JSON_TRANSFORMER);
+        get(apiPrefix + "graphql/schema", GraphQLController::getSchema, JSON_TRANSFORMER);
+        post(apiPrefix + "graphql/schema", GraphQLController::getSchema, JSON_TRANSFORMER);
+    }
+
+}
+

--- a/src/main/java/com/conveyal/gtfs/JsonTransformer.java
+++ b/src/main/java/com/conveyal/gtfs/JsonTransformer.java
@@ -1,0 +1,61 @@
+package com.conveyal.gtfs;
+
+import com.conveyal.geojson.GeometryDeserializer;
+import com.conveyal.geojson.GeometrySerializer;
+import com.conveyal.gtfs.model.Frequency;
+import com.conveyal.gtfs.model.Pattern;
+import com.conveyal.gtfs.model.Service;
+import com.conveyal.gtfs.model.Shape;
+import com.conveyal.gtfs.model.Trip;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Joiner;
+import com.vividsolutions.jts.geom.LineString;
+import spark.Request;
+import spark.Response;
+import spark.ResponseTransformer;
+
+import java.util.Map;
+
+/**
+ * Serve output as json.
+ */
+
+public class JsonTransformer implements ResponseTransformer {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String render(Object o) throws Exception {
+//        objectMapper.getSerializationConfig().addMixInAnnotations(Trip.class, TripMixIn.class);
+//        objectMapper.getDeserializationConfig().addMixInAnnotations(Trip.class, TripMixIn.class);
+        objectMapper.addMixIn(Trip.class, TripMixIn.class);
+        objectMapper.addMixIn(Frequency.class, FrequencyMixIn.class);
+        objectMapper.addMixIn(Pattern.class, PatternMixin.class);
+        return objectMapper.writeValueAsString(o);
+    }
+
+    /** set the content type */
+    public void type (Request request, Response response) {
+        response.type("application/json");
+    }
+
+    public abstract class TripMixIn {
+        @JsonIgnore public Map<Integer, Shape> shape_points;
+        @JsonIgnore public Service service;
+    }
+
+    public abstract class FrequencyMixIn {
+        @JsonIgnore public Trip trip;
+    }
+
+    public abstract class PatternMixin {
+        @JsonSerialize(using = GeometrySerializer.class)
+        @JsonDeserialize(using = GeometryDeserializer.class)
+        public LineString geometry;
+
+        @JsonIgnore
+        public Joiner joiner;
+    }
+}


### PR DESCRIPTION
I cleaned up the gtfs-api project after our big JDBC / RDBMS refactor, removing all dead code. There were only a few classes left. I moved the ones that define the GraphQL schema and provide a String-based API into the `gtfs-lib` project and the HTTP layer here, into `datatools-server`. That way the HTTP layer is handled in the project that has the web framework as a dependency.

This allows us to eliminate the gtfs-api project entirely.