### PR TITLE
Mapdb corruption fix

### DIFF
--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/ScheduleExceptionController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/ScheduleExceptionController.java
@@ -176,6 +176,7 @@ public class ScheduleExceptionController {
         return null;
     }
 
+    /** Check that no dates for the schedule exception are repeated across all schedule exceptions for the feed. */
     private static void checkDuplicateDates(ScheduleException ex, Collection<ScheduleException> exceptions) {
         if (ex.dates != null) {
             for (LocalDate date : ex.dates) {

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/ScheduleExceptionController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/ScheduleExceptionController.java
@@ -181,7 +181,9 @@ public class ScheduleExceptionController {
         if (ex.dates != null) {
             for (LocalDate date : ex.dates) {
                 // This is inefficient, but it keeps us from using the scheduleExceptionCountByDate map
-                // which had significant issues with mapdb corruption for some reason.
+                // which had significant issues with mapdb corruption likely due to the use of BindUtils.multiHistogram
+                // which we believe is making an auto-updated view or triggers or something. It's likely that there's some
+                // bug in combining these views with transactions.
                 for (ScheduleException exception : exceptions) {
                     if (exception.dates.contains(date)) {
                         halt(400);

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/ScheduleExceptionController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/ScheduleExceptionController.java
@@ -6,6 +6,7 @@ import com.conveyal.datatools.editor.datastore.VersionedDataStore;
 import com.conveyal.datatools.editor.models.transit.ScheduleException;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collection;
 
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
@@ -99,14 +100,7 @@ public class ScheduleExceptionController {
             if (tx.exceptions.containsKey(ex.id)) {
                 halt(400);
             }
-            if (ex.dates != null) {
-                for (LocalDate date : ex.dates) {
-                    if (tx.scheduleExceptionCountByDate.containsKey(date) && tx.scheduleExceptionCountByDate.get(date) > 0) {
-                        halt(400);
-                    }
-                }
-            }
-
+            checkDuplicateDates(ex, tx.exceptions.values());
             tx.exceptions.put(ex.id, ex);
 
             tx.commit();
@@ -164,6 +158,7 @@ public class ScheduleExceptionController {
                 halt(400);
             }
 
+            checkDuplicateDates(ex, tx.exceptions.values());
             tx.exceptions.put(ex.id, ex);
 
             tx.commit();
@@ -180,7 +175,21 @@ public class ScheduleExceptionController {
         }
         return null;
     }
-    
+
+    private static void checkDuplicateDates(ScheduleException ex, Collection<ScheduleException> exceptions) {
+        if (ex.dates != null) {
+            for (LocalDate date : ex.dates) {
+                // This is inefficient, but it keeps us from using the scheduleExceptionCountByDate map
+                // which had significant issues with mapdb corruption for some reason.
+                for (ScheduleException exception : exceptions) {
+                    if (exception.dates.contains(date)) {
+                        halt(400);
+                    }
+                }
+            }
+        }
+    }
+
     public static Object deleteScheduleException (Request req, Response res) {
         String id = req.params("id");
         String feedId = req.queryParams("feedId");

--- a/src/main/java/com/conveyal/datatools/editor/datastore/FeedTx.java
+++ b/src/main/java/com/conveyal/datatools/editor/datastore/FeedTx.java
@@ -63,7 +63,8 @@ public class FeedTx extends DatabaseTx {
     public NavigableSet<Tuple2<String, String>> tripPatternsByStop;
 
     /** number of schedule exceptions on each date - this will always be null, 0, or 1, as we prevent save of others */
-    public ConcurrentMap<LocalDate, Long> scheduleExceptionCountByDate;
+    // This has been removed because it has been found to cause corruption for mapdb for some unknown reason.
+//    public ConcurrentMap<LocalDate, Long> scheduleExceptionCountByDate;
 
     /** number of trips on each tuple2<patternId, calendar id> */
     public ConcurrentMap<Tuple2<String, String>, Long> tripCountByPatternAndCalendar;
@@ -165,30 +166,31 @@ public class FeedTx extends DatabaseTx {
         tripCountByPatternAndCalendar = getMap("tripCountByPatternAndCalendar");
         Bind.histogram(trips, tripCountByPatternAndCalendar, (tripId, trip) -> new Tuple2(trip.patternId, trip.calendarId));
 
+        // Removed scheduleExceptionCountByDate due to corruption issues.
         // getting schedule exception map appears to be causing issues for some feeds
         // The names of the code writers have been changed to protect the innocent.
-        try {
-            scheduleExceptionCountByDate = getMap("scheduleExceptionCountByDate");
-        } catch (RuntimeException e1) {
-            LOG.error("Error getting scheduleExceptionCountByDate map. Getting a new one.");
-            int count = 0;
-            final int NEW_MAP_LIMIT = 100;
-            while (true) {
-                try {
-                    scheduleExceptionCountByDate = getMap("scheduleExceptionCountByDateMapDBIsTheWORST" + count);
-                } catch (RuntimeException e2) {
-                    LOG.error("Error getting {} scheduleExceptionCountByDateMapDBIsTheWORST map. Getting a new one.", count);
-                    count++;
-                    if (count > NEW_MAP_LIMIT) {
-                        LOG.error("Cannot create new map. Reached limit of {}", NEW_MAP_LIMIT);
-                        throw e2;
-                    }
-                    continue;
-                }
-                break;
-            }
-        }
-        BindUtils.multiHistogram(exceptions, scheduleExceptionCountByDate, (id, ex) -> ex.dates.toArray(new LocalDate[ex.dates.size()]));
+//        try {
+//            scheduleExceptionCountByDate = getMap("scheduleExceptionCountByDate");
+//        } catch (RuntimeException e1) {
+//            LOG.error("Error getting scheduleExceptionCountByDate map. Getting a new one.");
+//            int count = 0;
+//            final int NEW_MAP_LIMIT = 100;
+//            while (true) {
+//                try {
+//                    scheduleExceptionCountByDate = getMap("scheduleExceptionCountByDateMapDBIsTheWORST" + count);
+//                } catch (RuntimeException e2) {
+//                    LOG.error("Error getting {} scheduleExceptionCountByDateMapDBIsTheWORST map. Getting a new one.", count);
+//                    count++;
+//                    if (count > NEW_MAP_LIMIT) {
+//                        LOG.error("Cannot create new map. Reached limit of {}", NEW_MAP_LIMIT);
+//                        throw e2;
+//                    }
+//                    continue;
+//                }
+//                break;
+//            }
+//        }
+//        BindUtils.multiHistogram(exceptions, scheduleExceptionCountByDate, (id, ex) -> ex.dates.toArray(new LocalDate[ex.dates.size()]));
 
         tripCountByCalendar = getMap("tripCountByCalendar");
         BindUtils.multiHistogram(trips, tripCountByCalendar, (key, trip) -> {
@@ -432,7 +434,8 @@ public class FeedTx extends DatabaseTx {
 
             // copy histograms
             pump(newDb, "tripCountByCalendar", (BTreeMap) feedTx.tripCountByCalendar);
-            pump(newDb, "scheduleExceptionCountByDate", (BTreeMap) feedTx.scheduleExceptionCountByDate);
+            // Removed scheduleExceptionCountByDate due to corruption issues
+//            pump(newDb, "scheduleExceptionCountByDate", (BTreeMap) feedTx.scheduleExceptionCountByDate);
             pump(newDb, "tripCountByPatternAndCalendar", (BTreeMap) feedTx.tripCountByPatternAndCalendar);
 
         }

--- a/src/main/java/com/conveyal/datatools/editor/datastore/FeedTx.java
+++ b/src/main/java/com/conveyal/datatools/editor/datastore/FeedTx.java
@@ -63,7 +63,9 @@ public class FeedTx extends DatabaseTx {
     public NavigableSet<Tuple2<String, String>> tripPatternsByStop;
 
     /** number of schedule exceptions on each date - this will always be null, 0, or 1, as we prevent save of others */
-    // This has been removed because it has been found to cause corruption for mapdb for some unknown reason.
+    // This has been removed because it has been found to cause corruption for mapdb. When shutting down the JVM, most
+    // MapDB tables seem to be closed cleanly, but this particular one (and perhaps others created with the bindHistogram
+    // method?) are not put into a clean state.
 //    public ConcurrentMap<LocalDate, Long> scheduleExceptionCountByDate;
 
     /** number of trips on each tuple2<patternId, calendar id> */
@@ -165,32 +167,6 @@ public class FeedTx extends DatabaseTx {
 
         tripCountByPatternAndCalendar = getMap("tripCountByPatternAndCalendar");
         Bind.histogram(trips, tripCountByPatternAndCalendar, (tripId, trip) -> new Tuple2(trip.patternId, trip.calendarId));
-
-        // Removed scheduleExceptionCountByDate due to corruption issues.
-        // getting schedule exception map appears to be causing issues for some feeds
-        // The names of the code writers have been changed to protect the innocent.
-//        try {
-//            scheduleExceptionCountByDate = getMap("scheduleExceptionCountByDate");
-//        } catch (RuntimeException e1) {
-//            LOG.error("Error getting scheduleExceptionCountByDate map. Getting a new one.");
-//            int count = 0;
-//            final int NEW_MAP_LIMIT = 100;
-//            while (true) {
-//                try {
-//                    scheduleExceptionCountByDate = getMap("scheduleExceptionCountByDateMapDBIsTheWORST" + count);
-//                } catch (RuntimeException e2) {
-//                    LOG.error("Error getting {} scheduleExceptionCountByDateMapDBIsTheWORST map. Getting a new one.", count);
-//                    count++;
-//                    if (count > NEW_MAP_LIMIT) {
-//                        LOG.error("Cannot create new map. Reached limit of {}", NEW_MAP_LIMIT);
-//                        throw e2;
-//                    }
-//                    continue;
-//                }
-//                break;
-//            }
-//        }
-//        BindUtils.multiHistogram(exceptions, scheduleExceptionCountByDate, (id, ex) -> ex.dates.toArray(new LocalDate[ex.dates.size()]));
 
         tripCountByCalendar = getMap("tripCountByCalendar");
         BindUtils.multiHistogram(trips, tripCountByCalendar, (key, trip) -> {

--- a/src/main/java/com/conveyal/datatools/editor/datastore/SnapshotTx.java
+++ b/src/main/java/com/conveyal/datatools/editor/datastore/SnapshotTx.java
@@ -67,7 +67,7 @@ public class SnapshotTx extends DatabaseTx {
         try {
             targetTx.getAll();
         } catch (RuntimeException e) {
-            LOG.error("Target FeedTX for feed restore may be corrupted.  Wiping feed database (it will be restored with a snapshot anyways).", e);
+            LOG.error("Target FeedTX for feed restore may be corrupted.  Deleting feed DB files (db will be restored with a snapshot anyways).", e);
             // This deletes the mapdb files entirely and is only used here because we are replacing with a new snapshot.
             VersionedDataStore.wipeFeedDB(agencyId);
             // Get fresh database transaction

--- a/src/main/java/com/conveyal/datatools/editor/datastore/SnapshotTx.java
+++ b/src/main/java/com/conveyal/datatools/editor/datastore/SnapshotTx.java
@@ -50,7 +50,8 @@ public class SnapshotTx extends DatabaseTx {
         // while we don't snapshot indices, we do need to snapshot histograms as they aren't restored
         // (mapdb ticket 453)
         pump("tripCountByCalendar", (BTreeMap) master.tripCountByCalendar);
-        pump("scheduleExceptionCountByDate", (BTreeMap) master.scheduleExceptionCountByDate);
+        // Removed scheduleExceptionCountByDate due to corruption issues
+//        pump("scheduleExceptionCountByDate", (BTreeMap) master.scheduleExceptionCountByDate);
         pump("tripCountByPatternAndCalendar", (BTreeMap) master.tripCountByPatternAndCalendar);
 
         this.commit();

--- a/src/main/java/com/conveyal/datatools/editor/datastore/SnapshotTx.java
+++ b/src/main/java/com/conveyal/datatools/editor/datastore/SnapshotTx.java
@@ -67,7 +67,11 @@ public class SnapshotTx extends DatabaseTx {
         try {
             targetTx.getAll();
         } catch (RuntimeException e) {
-            LOG.error("Target FeedTX for feed restore may be corrupted.  Consider wiping feed database editor/$FEED_ID/master.db*", e);
+            LOG.error("Target FeedTX for feed restore may be corrupted.  Wiping feed database (it will be restored with a snapshot anyways).", e);
+            // This deletes the mapdb files entirely and is only used here because we are replacing with a new snapshot.
+            VersionedDataStore.wipeFeedDB(agencyId);
+            // Get fresh database transaction
+            targetTx = VersionedDataStore.getRawFeedTx(agencyId);
         }
         for (String obj : targetTx.getAll().keySet()) {
             if (obj.equals("snapshotVersion")


### PR DESCRIPTION
This more or less "fixes" most of the MapDB corruption issues.  The approach is two-fold:

1. Remove the problematic `scheduleExceptionCountByDate` map, which for some unknown reason often becomes corrupt and may be the cause of the larger DB failing.
2. Entirely wipes the feed DB (deletes the mapdb files) when restoring a snapshot.  This seems to be ok, because we're overwriting all of the data anyways, so it shouldn't hurt to just create a fresh DB in the process.  The only thing that is impacted is that the `snapshotVersion` is lost, but this was fixed in previous work to [increment the snapshot version number to the next available value](https://github.com/catalogueglobal/datatools-server/blob/799ff28ecf1c4be65d3e9289fd9ae741daa71bcf/src/main/java/com/conveyal/datatools/editor/datastore/VersionedDataStore.java#L132-L140).