### PR TITLE
Restrict feed downloads for demo users

### DIFF
--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -22,6 +22,7 @@ import com.conveyal.datatools.manager.models.FeedVersion;
 import com.conveyal.datatools.manager.models.JsonViews;
 import com.conveyal.datatools.manager.persistence.FeedStore;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
+import org.apache.http.HttpStatus;
 import org.mapdb.Fun;
 import org.mapdb.Fun.Tuple2;
 import org.slf4j.Logger;
@@ -247,6 +248,10 @@ public class SnapshotController {
 
     /** Export a snapshot as GTFS */
     public static Object getSnapshotToken(Request req, Response res) {
+        Auth0UserProfile userProfile = req.attribute("user");
+        if (userProfile.isExportRestricted()) {
+            halt(HttpStatus.SC_UNAUTHORIZED, "Demo account user unauthorized to download data.");
+        }
         String id = req.params("id");
         Tuple2<String, Integer> decodedId;
         FeedDownloadToken token;

--- a/src/main/java/com/conveyal/datatools/manager/auth/Auth0UserProfile.java
+++ b/src/main/java/com/conveyal/datatools/manager/auth/Auth0UserProfile.java
@@ -269,6 +269,22 @@ public class Auth0UserProfile {
         return false;
     }
 
+    /**
+     * Checks if user is restricted from downloading data from the data tools application. The primary use case for this
+     * flag is for demo account users. The `export-restricted` flag must be included in the application-level permissions
+     * for this to return true.
+     */
+    public boolean isExportRestricted() {
+        if(app_metadata.getDatatoolsInfo() != null && app_metadata.getDatatoolsInfo().permissions != null) {
+            for(Permission permission : app_metadata.getDatatoolsInfo().permissions) {
+                if(permission.type.equals("export-restricted")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     public Organization getAuth0Organization() {
         if(app_metadata.getDatatoolsInfo() != null && app_metadata.getDatatoolsInfo().organizations != null && app_metadata.getDatatoolsInfo().organizations.length != 0) {
             return app_metadata.getDatatoolsInfo().organizations[0];

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/DeploymentController.java
@@ -14,6 +14,7 @@ import com.conveyal.datatools.manager.utils.json.JsonManager;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
@@ -94,6 +95,10 @@ public class DeploymentController {
 
         if (!userProfile.canAdministerProject(d.projectId, d.getOrganizationId()) && !userProfile.getUser_id().equals(d.getUser()))
             halt(401);
+
+        if (userProfile.isExportRestricted()) {
+            halt(HttpStatus.SC_UNAUTHORIZED, "Demo account user unauthorized to download data.");
+        }
 
         File temp = File.createTempFile("deployment", ".zip");
         // just include GTFS, not any of the ancillary information

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
@@ -353,6 +354,12 @@ public class FeedVersionController  {
      */
     public static Object getFeedDownloadCredentials(Request req, Response res) {
         FeedVersion version = requestFeedVersion(req, "view");
+
+        Auth0UserProfile userProfile = req.attribute("user");
+
+        if (userProfile.isExportRestricted()) {
+            halt(HttpStatus.SC_UNAUTHORIZED, "Demo account user unauthorized to download data.");
+        }
 
         // if storing feeds on s3, return temporary s3 credentials for that zip file
         if (DataManager.useS3) {

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/ProjectController.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -266,6 +267,11 @@ public class ProjectController {
     private static boolean downloadMergedFeed(Request req, Response res) throws IOException {
         Project project = requestProjectById(req, "view");
         Auth0UserProfile userProfile = req.attribute("user");
+
+        if (userProfile.isExportRestricted()) {
+            halt(HttpStatus.SC_UNAUTHORIZED, "Demo account user unauthorized to download data.");
+        }
+
         // TODO: make this an authenticated call?
         MergeProjectFeedsJob mergeProjectFeedsJob = new MergeProjectFeedsJob(project, userProfile.getUser_id());
         DataManager.heavyExecutor.execute(mergeProjectFeedsJob);


### PR DESCRIPTION
This PR simply adds a halt on HTTP endpoints that allow users to download GTFS feeds from the application.  This is intended to allow demo users to access the application (specifically the editor) but not download any data they create.  There are no corresponding UI changes at this point.  To restrict downloads for a user, the following permissions should be added to the Auth0 user's app_metadata `permissions` object:

```json
{
  "type": "export-restricted"
}
```