### PR TITLE
Use presigned URLs for S3 downloads

### DIFF
--- a/configurations/default/server.yml.tmp
+++ b/configurations/default/server.yml.tmp
@@ -7,7 +7,6 @@ application:
     gtfs: /tmp
     use_s3_storage: false
     s3_region: us-east-1
-    aws_role: arn:aws:iam::${AWS_ACCOUNT_NUMBER}:role/${AWS_ROLE_NAME}
     gtfs_s3_bucket: bucket-name
 modules:
   enterprise:

--- a/src/main/java/com/conveyal/datatools/common/utils/S3Utils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/S3Utils.java
@@ -1,6 +1,7 @@
 package com.conveyal.datatools.common.utils;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.HttpMethod;
 import com.amazonaws.auth.policy.Action;
 import com.amazonaws.auth.policy.Policy;
 import com.amazonaws.auth.policy.Resource;
@@ -9,6 +10,7 @@ import com.amazonaws.auth.policy.actions.S3Actions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
@@ -21,6 +23,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
+import spark.Response;
 
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletException;
@@ -29,6 +32,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,6 +46,7 @@ import static spark.Spark.halt;
 public class S3Utils {
 
     private static final Logger LOG = LoggerFactory.getLogger(S3Utils.class);
+    private static final int REQUEST_TIMEOUT_MSEC = 30 * 1000;
 
     public static String uploadBranding(Request req, String key) throws IOException, ServletException {
         String url;
@@ -91,37 +97,30 @@ public class S3Utils {
     }
 
     /**
-     * Create temporary S3 credentials in order to grant access to some set of objects (s3://bucket/key)
-     * using a predefined role.  More info here: http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/prog-services-sts.html#retrieving-an-sts-token
-     * @param role predefined AWS role that must be used as the baseline for allowable actions, effects, and resources
-     * @param bucket S3 bucket name
-     * @param key S3 key to grant access to
-     * @param effect policy statement effect (for example, GetObject)
-     * @param action action allowed by temporary credentials (must intersect with the policies already defined by role)
-     * @param durationSeconds duration in seconds that the credentials are valid for (900 is minumum)
+     * Download an object in the selected format from S3, using presigned URLs.
+     * @param s3
+     * @param bucket name of the bucket
+     * @param filename both the key and the format
+     * @param redirect
+     * @param res
      * @return
      */
-    public static Credentials getS3Credentials(String role, String bucket, String key, Statement.Effect effect, S3Actions action, int durationSeconds) {
-        AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.defaultClient();
-        Policy policy = new Policy();
-        policy.setId("datatools-feed-access");
-        Statement statement = new Statement(effect);
-        Set<Action> actions = new HashSet<>();
-        actions.add(action);
-        statement.setActions(actions);
-        Set<Resource> resources = new HashSet<>();
-        resources.add(new Resource("arn:aws:s3:::" + bucket + "/" + key));
-        statement.setResources(resources);
-        Set<Statement> statements = new HashSet<>();
-        statements.add(statement);
-        policy.setStatements(statements);
-        AssumeRoleRequest assumeRequest = new AssumeRoleRequest()
-                .withRoleArn(role)
-                .withPolicy(policy.toJson()) // some policy that limits access to certain objects (intersects with ROLE_ARN policies
-                .withDurationSeconds(durationSeconds) // 900 is minimum duration (seconds)
-                .withRoleSessionName("feed-access");
-        AssumeRoleResult assumeResult =
-                stsClient.assumeRole(assumeRequest);
-        return assumeResult.getCredentials();
+    public static Object downloadFromS3(AmazonS3 s3, String bucket, String filename, boolean redirect, Response res){
+        Date expiration = new Date();
+        expiration.setTime(expiration.getTime() + REQUEST_TIMEOUT_MSEC);
+
+        GeneratePresignedUrlRequest presigned = new GeneratePresignedUrlRequest(bucket, filename);
+        presigned.setExpiration(expiration);
+        presigned.setMethod(HttpMethod.GET);
+        URL url = s3.generatePresignedUrl(presigned);
+
+        if (redirect) {
+            res.type("text/plain"); // override application/json
+            res.redirect(url.toString());
+            res.status(302); // temporary redirect, this URL will soon expire
+            return null;
+        } else {
+            return SparkUtils.formatJSON("url", url.toString());
+        }
     }
 }

--- a/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/SparkUtils.java
@@ -45,6 +45,12 @@ public class SparkUtils {
         return res.raw();
     }
 
+    public static String formatJSON (String key, String value) {
+        ObjectNode object = mapper.createObjectNode();
+        object.put(key, value);
+        return object.toString();
+    }
+
     public static String formatJSON(String message, int code, Exception e) {
         String detail = e != null ? e.getMessage() : null;
         ObjectNode object = mapper.createObjectNode();

--- a/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
+++ b/src/main/java/com/conveyal/datatools/editor/controllers/api/SnapshotController.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 import spark.Request;
 import spark.Response;
 
-import static com.conveyal.datatools.common.utils.S3Utils.getS3Credentials;
+import static com.conveyal.datatools.common.utils.S3Utils.downloadFromS3;
 import static com.conveyal.datatools.common.utils.SparkUtils.*;
 import static spark.Spark.*;
 
@@ -186,16 +186,10 @@ public class SnapshotController {
             if (!FeedStore.s3Client.doesObjectExist(DataManager.feedBucket, key)) {
                 haltWithMessage(400, String.format("Error downloading snapshot from S3. Object %s does not exist.", key));
             }
-            return getS3Credentials(
-                    DataManager.awsRole,
-                    DataManager.feedBucket,
-                    key,
-                    Statement.Effect.Allow,
-                    S3Actions.GetObject,
-                    900
-            );
+            // Return presigned download link if using S3.
+            return downloadFromS3(FeedStore.s3Client, DataManager.feedBucket, key, false, res);
         } else {
-            // if not storing on s3, just use the token download method
+            // If not storing on s3, just use the token download method.
             token = new FeedDownloadToken(snapshot);
             Persistence.tokens.create(token);
             return token;

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -53,7 +53,7 @@ import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequestWrapper;
 
 import static com.conveyal.datatools.common.status.MonitorableJob.JobType.BUILD_TRANSPORT_NETWORK;
-import static com.conveyal.datatools.common.utils.S3Utils.getS3Credentials;
+import static com.conveyal.datatools.common.utils.S3Utils.downloadFromS3;
 import static com.conveyal.datatools.common.utils.SparkUtils.downloadFile;
 import static com.conveyal.datatools.common.utils.SparkUtils.formatJobMessage;
 import static com.conveyal.datatools.common.utils.SparkUtils.haltWithMessage;
@@ -370,9 +370,9 @@ public class FeedVersionController  {
     public static Object getFeedDownloadCredentials(Request req, Response res) {
         FeedVersion version = requestFeedVersion(req, "view");
 
-        // if storing feeds on s3, return temporary s3 credentials for that zip file
         if (DataManager.useS3) {
-            return getS3Credentials(DataManager.awsRole, DataManager.feedBucket, FeedStore.s3Prefix + version.id, Statement.Effect.Allow, S3Actions.GetObject, 900);
+            // Return presigned download link if using S3.
+            return downloadFromS3(FeedStore.s3Client, DataManager.feedBucket, FeedStore.s3Prefix + version.id, false, res);
         } else {
             // when feeds are stored locally, single-use download token will still be used
             FeedDownloadToken token = new FeedDownloadToken(version);


### PR DESCRIPTION
This PR (along with https://github.com/catalogueglobal/datatools-ui/pull/193) replaces the use of S3 temporary credentials with presigned URLs to download S3 objects.