### PR TITLE
Use Auth0 lib to verify JWT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,11 @@
             <version>[3.0,4.0)</version>
             <artifactId>bugsnag</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>2.1.0</version>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
This PR fixes #105. Specifically it verifies the token found in the API request with the `JWTVerifier#verify` method rather than using the token to call the Auth0 `/tokeninfo` endpoint.