### PR TITLE
Bump gtfs-lib to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>4.0.0</version>
+            <version>4.1.0</version>
         </dependency>
 
         <!-- Used for data-tools application database -->


### PR DESCRIPTION
Incorporate new features from [gtfs-lib release 4.1.0](https://github.com/conveyal/gtfs-lib/releases/tag/v4.1.0).