### PR TITLE
Bump gtfs-lib for bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.1</version>
         </dependency>
 
         <!-- Used for data-tools application database -->


### PR DESCRIPTION
Bump to [4.1.1](https://github.com/conveyal/gtfs-lib/releases/tag/v4.1.1) for bug fixes.